### PR TITLE
test(ui): jsdom behavioral tests for the gallery UI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,22 @@ jobs:
       - uses: golangci/golangci-lint-action@v7
         with:
           version: latest
+
+  js:
+    name: ui (jsdom + typecheck)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: test/ui/package-lock.json
+      - name: install
+        working-directory: test/ui
+        run: npm ci
+      - name: jsdom tests
+        working-directory: test/ui
+        run: npm test
+      - name: typecheck UI (JSDoc + checkJs)
+        run: npx -y -p typescript tsc -p cmd/swapbook/ui/jsconfig.json

--- a/test/ui/app.test.mjs
+++ b/test/ui/app.test.mjs
@@ -1,0 +1,55 @@
+// Behavioral tests for the Swapbook chrome (app.js), driven through jsdom.
+// Focus: the first-run states (target down vs adapter-not-mounted) and the
+// inspector's "ready" line, none of which the Go tests can reach.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { boot, res, MANIFEST } from "./harness.mjs";
+
+const txt = (w, id) => (w.document.getElementById(id)?.textContent || "").trim();
+const errShown = (w) => w.document.getElementById("stage-error").hidden === false;
+
+test("adapter answers: stories render, no error overlay", async () => {
+  const w = await boot(
+    async () => res(200, MANIFEST),
+    (w) => txt(w, "stories").includes("Button"),
+  );
+  assert.equal(errShown(w), false);
+  assert.match(txt(w, "stories"), /Button/);
+  assert.match(txt(w, "stories"), /Todo list/);
+});
+
+test("target up but no adapter (404): dedicated 'no adapter' screen", async () => {
+  const w = await boot(
+    async () => res(404, "<html>404 not found</html>"),
+    (w) => errShown(w),
+  );
+  assert.equal(errShown(w), true);
+  assert.equal(txt(w, "err-title"), "no swapbook adapter");
+  assert.match(txt(w, "err-sub"), /mount the adapter/i);
+  assert.match(txt(w, "err-sub"), /_swapbook/);
+});
+
+test("target unreachable (network error): 'target unreachable' screen", async () => {
+  const w = await boot(
+    async () => {
+      throw new Error("ECONNREFUSED");
+    },
+    (w) => errShown(w),
+  );
+  assert.equal(errShown(w), true);
+  assert.equal(txt(w, "err-title"), "target unreachable");
+});
+
+test("inspector ready line flags non-htmx probes as beta", async () => {
+  const w = await boot(
+    async () => res(200, MANIFEST),
+    (w) => txt(w, "stories").includes("Button"),
+  );
+  w.onReady({ libs: ["htmx", "turbo", "datastar"] });
+  const line = txt(w, "events");
+  assert.match(line, /hypermedia:/);
+  assert.match(line, /htmx/);
+  assert.match(line, /turbo \(beta\)/);
+  assert.match(line, /datastar \(beta\)/);
+  assert.doesNotMatch(line, /htmx \(beta\)/);
+});

--- a/test/ui/harness.mjs
+++ b/test/ui/harness.mjs
@@ -1,0 +1,59 @@
+// Loads the real Swapbook browser UI (index.html + app.js, unmodified) into a
+// jsdom window with a stubbed fetch, so tests exercise the actual client logic.
+// This is dev-only tooling; the shipped UI stays a plain <script>, no build.
+import { readFileSync } from "node:fs";
+
+const UI = new URL("../../cmd/swapbook/ui/", import.meta.url);
+const HTML = readFileSync(new URL("index.html", UI), "utf8")
+  .replace(/<script[^>]*app\.js[^>]*><\/script>/, ""); // we inject app.js ourselves
+const APP = readFileSync(new URL("app.js", UI), "utf8");
+
+/** A minimal fetch Response for a given status + body. */
+export function res(status, body) {
+  return { ok: status >= 200 && status < 300, status, text: async () => body };
+}
+
+/**
+ * Boot the UI with a fetch stub, then wait until `ready(window)` is truthy.
+ * Returns the jsdom window.
+ */
+export async function boot(fetchImpl, ready) {
+  const { JSDOM } = await import("jsdom");
+  const dom = new JSDOM(HTML, {
+    runScripts: "dangerously",
+    url: "http://localhost/__sb/",
+    pretendToBeVisual: true,
+  });
+  const w = dom.window;
+  w.fetch = fetchImpl;
+  w.setInterval = () => 0; // app.js starts a 1.5s reconnect poller; skip it so
+  //                          jsdom timers don't keep the test process alive.
+
+  const s = w.document.createElement("script");
+  s.textContent = APP; // top-level function decls attach to the window global
+  w.document.body.appendChild(s); // runs app.js -> boot()
+
+  for (let i = 0; i < 100; i++) {
+    if (ready(w)) return w;
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  return w; // let the assertion report the failure
+}
+
+/** Manifest JSON with a couple of stories, one carrying a control + a mock. */
+export const MANIFEST = JSON.stringify({
+  htmxSrc: "",
+  cssSrc: "/static/ds.css",
+  stories: [
+    {
+      id: "button",
+      name: "Button",
+      group: "actions",
+      variants: [
+        { name: "primary" },
+        { name: "controls", controls: [{ name: "label", type: "text", default: "Save" }] },
+      ],
+    },
+    { id: "todo-list", name: "Todo list", group: "interactive", variants: [{ name: "default" }] },
+  ],
+});

--- a/test/ui/inspector-harness.mjs
+++ b/test/ui/inspector-harness.mjs
@@ -1,0 +1,49 @@
+// Loads the real inspector.js (the script injected into every preview frame)
+// into a jsdom window, faking whichever hypermedia library the test wants so the
+// matching probe attaches. Lets tests drive each library's request lifecycle and
+// observe the shared mock/safe/live gating.
+import { readFileSync } from "node:fs";
+
+const SRC = readFileSync(new URL("../../cmd/swapbook/ui/inspector.js", import.meta.url), "utf8");
+
+/**
+ * @param {{mode?: string, mocks?: Record<string,string>, libs?: string[], body?: string}} opts
+ */
+export async function loadInspector(opts = {}) {
+  const libs = opts.libs || ["htmx"];
+  const { JSDOM } = await import("jsdom");
+  const dom = new JSDOM(`<!doctype html><body>${opts.body || ""}</body>`, {
+    runScripts: "dangerously",
+    url: "http://localhost/",
+  });
+  const w = dom.window;
+  const messages = [];
+  const upHandlers = {}; // unpoly registers via up.on(name, fn); we capture them
+  const fetchCalls = []; // what datastar's wrapper forwarded to the original fetch
+
+  w.__SB = { mode: opts.mode || "mock", mocks: opts.mocks || {} };
+  // datastar wraps window.fetch; give it a spyable original to forward to.
+  w.fetch = (input, init) => {
+    fetchCalls.push({ input: String(input && input.url ? input.url : input), init });
+    return Promise.resolve({ status: 200 });
+  };
+  if (libs.includes("htmx")) w.htmx = {};
+  if (libs.includes("turbo")) w.Turbo = {};
+  if (libs.includes("unpoly")) w.up = { on: (name, fn) => { upHandlers[name] = fn; } };
+  if (libs.includes("datastar")) w.Datastar = {};
+  w.postMessage = (m) => messages.push(m); // send() posts to parent === window here
+
+  const s = w.document.createElement("script");
+  s.textContent = SRC;
+  w.document.body.appendChild(s); // runs the inspector IIFE -> wire()
+
+  /** Dispatch a document CustomEvent with a mutable detail; returns the event. */
+  function fire(name, detail, cancelable = true) {
+    const e = new w.CustomEvent(name, { detail, cancelable, bubbles: true });
+    w.document.dispatchEvent(e);
+    return e;
+  }
+  const events = (name) => messages.filter((m) => m.event === name);
+
+  return { w, messages, fire, events, upHandlers, fetchCalls, close: () => w.close() };
+}

--- a/test/ui/inspector-probes.test.mjs
+++ b/test/ui/inspector-probes.test.mjs
@@ -1,0 +1,87 @@
+// The non-htmx probes (Turbo, Unpoly, Datastar) share the same mock/safe/live
+// gate but reroute/cancel through each library's own mechanism. htmx is the
+// verified flagship; these assert the best-effort probes actually gate.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { loadInspector } from "./inspector-harness.mjs";
+
+const MOCKS = { "GET /rows": "/__sb/mock/s/v/0" };
+
+// ---- Turbo (turbo:before-fetch-request document event) --------------------
+
+test("turbo: mocked GET is rerouted to the mock endpoint", async () => {
+  const sb = await loadInspector({ libs: ["turbo"], mode: "mock", mocks: MOCKS });
+  assert.deepEqual(Array.from(sb.events("frame:ready")[0].data.libs), ["turbo"]);
+  const detail = { url: "http://localhost/rows", fetchOptions: { method: "GET" } };
+  sb.fire("turbo:before-fetch-request", detail);
+  assert.match(String(detail.url), /\/__sb\/mock\/s\/v\/0$/);
+  assert.equal(sb.events("mock").length, 1);
+  sb.close();
+});
+
+test("turbo: unmocked mutation is blocked (preventDefault)", async () => {
+  const sb = await loadInspector({ libs: ["turbo"], mode: "mock", mocks: MOCKS });
+  const e = sb.fire("turbo:before-fetch-request", { url: "http://localhost/save", fetchOptions: { method: "POST" } });
+  assert.equal(e.defaultPrevented, true);
+  assert.equal(sb.events("blocked").length, 1);
+  sb.close();
+});
+
+test("turbo: live mode lets a mutation through", async () => {
+  const sb = await loadInspector({ libs: ["turbo"], mode: "live", mocks: MOCKS });
+  const e = sb.fire("turbo:before-fetch-request", { url: "http://localhost/save", fetchOptions: { method: "POST" } });
+  assert.equal(e.defaultPrevented, false);
+  assert.equal(sb.events("blocked").length, 0);
+  sb.close();
+});
+
+// ---- Unpoly (up.on("up:request:load")) ------------------------------------
+
+test("unpoly: mocked GET has its request url rewritten", async () => {
+  const sb = await loadInspector({ libs: ["unpoly"], mode: "mock", mocks: MOCKS });
+  const req = { method: "GET", url: "http://localhost/rows" };
+  sb.upHandlers["up:request:load"]({ request: req });
+  assert.equal(req.url, "/__sb/mock/s/v/0");
+  assert.equal(sb.events("mock").length, 1);
+  sb.close();
+});
+
+test("unpoly: unmocked mutation is blocked", async () => {
+  const sb = await loadInspector({ libs: ["unpoly"], mode: "mock", mocks: MOCKS });
+  let prevented = false;
+  sb.upHandlers["up:request:load"]({
+    request: { method: "POST", url: "http://localhost/save" },
+    preventDefault: () => { prevented = true; },
+  });
+  assert.equal(prevented, true);
+  assert.equal(sb.events("blocked").length, 1);
+  sb.close();
+});
+
+// ---- Datastar (wraps window.fetch) ----------------------------------------
+
+test("datastar: mocked GET forwards to the mock url", async () => {
+  const sb = await loadInspector({ libs: ["datastar"], mode: "mock", mocks: MOCKS });
+  await sb.w.fetch("http://localhost/rows", { method: "GET" });
+  assert.equal(sb.fetchCalls.length, 1);
+  assert.equal(sb.fetchCalls[0].input, "/__sb/mock/s/v/0");
+  assert.equal(sb.events("mock").length, 1);
+  sb.close();
+});
+
+test("datastar: unmocked mutation is rejected, original fetch never called", async () => {
+  const sb = await loadInspector({ libs: ["datastar"], mode: "mock", mocks: MOCKS });
+  await assert.rejects(() => sb.w.fetch("http://localhost/save", { method: "POST" }), /blocked by swapbook/);
+  assert.equal(sb.fetchCalls.length, 0);
+  assert.equal(sb.events("blocked").length, 1);
+  sb.close();
+});
+
+test("datastar: live mode forwards untouched to the original fetch", async () => {
+  const sb = await loadInspector({ libs: ["datastar"], mode: "live", mocks: MOCKS });
+  await sb.w.fetch("http://localhost/save", { method: "POST" });
+  assert.equal(sb.fetchCalls.length, 1);
+  assert.equal(sb.fetchCalls[0].input, "http://localhost/save");
+  assert.equal(sb.events("blocked").length, 0);
+  sb.close();
+});

--- a/test/ui/inspector.test.mjs
+++ b/test/ui/inspector.test.mjs
@@ -1,0 +1,82 @@
+// The core product promise: the inspector gates htmx traffic per mode.
+//   mock  - mocked routes rerouted to the mock endpoint; unmocked writes blocked
+//   safe  - real requests, all mutations blocked
+//   live  - everything passes through
+// These are driven through jsdom against the real inspector.js.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { loadInspector } from "./inspector-harness.mjs";
+
+const MOCKS = { "GET /rows": "/__sb/mock/s/v/0", "POST /save-mocked": "/__sb/mock/s/v/1" };
+
+test("htmx probe attaches and announces itself", async () => {
+  const sb = await loadInspector({ mode: "mock", mocks: MOCKS });
+  const ready = sb.events("frame:ready");
+  assert.equal(ready.length, 1);
+  assert.deepEqual(Array.from(ready[0].data.libs), ["htmx"]);
+  assert.equal(ready[0].data.mode, "mock");
+  sb.close();
+});
+
+test("mock mode: a mocked route is rerouted to its mock endpoint", async () => {
+  const sb = await loadInspector({ mode: "mock", mocks: MOCKS });
+  const detail = { verb: "get", path: "/rows" };
+  sb.fire("htmx:configRequest", detail);
+  assert.equal(detail.path, "/__sb/mock/s/v/0"); // rewritten in place
+  assert.equal(sb.events("mock").length, 1);
+  sb.close();
+});
+
+test("mock mode: an unmocked route is left untouched", async () => {
+  const sb = await loadInspector({ mode: "mock", mocks: MOCKS });
+  const detail = { verb: "get", path: "/nope" };
+  sb.fire("htmx:configRequest", detail);
+  assert.equal(detail.path, "/nope");
+  assert.equal(sb.events("mock").length, 0);
+  sb.close();
+});
+
+test("mock mode: an unmocked mutation is blocked", async () => {
+  const sb = await loadInspector({ mode: "mock", mocks: MOCKS });
+  const e = sb.fire("htmx:beforeRequest", { requestConfig: { verb: "post", path: "/save" } });
+  assert.equal(e.defaultPrevented, true);
+  assert.equal(sb.events("blocked").length, 1);
+  sb.close();
+});
+
+test("mock mode: a GET is never blocked (not a mutation)", async () => {
+  const sb = await loadInspector({ mode: "mock", mocks: MOCKS });
+  const e = sb.fire("htmx:beforeRequest", { requestConfig: { verb: "get", path: "/rows" } });
+  assert.equal(e.defaultPrevented, false);
+  assert.equal(sb.events("blocked").length, 0);
+  sb.close();
+});
+
+test("safe mode: mutation blocked, but no mock rerouting", async () => {
+  const sb = await loadInspector({ mode: "safe", mocks: MOCKS });
+  // safe never reroutes, even for a declared mock
+  const detail = { verb: "post", path: "/save-mocked" };
+  sb.fire("htmx:configRequest", detail);
+  assert.equal(detail.path, "/save-mocked");
+  // but it still blocks the mutation
+  const e = sb.fire("htmx:beforeRequest", { requestConfig: { verb: "post", path: "/save-mocked" } });
+  assert.equal(e.defaultPrevented, true);
+  assert.equal(sb.events("blocked").length, 1);
+  sb.close();
+});
+
+test("live mode: mutations pass through untouched", async () => {
+  const sb = await loadInspector({ mode: "live", mocks: MOCKS });
+  const e = sb.fire("htmx:beforeRequest", { requestConfig: { verb: "post", path: "/save" } });
+  assert.equal(e.defaultPrevented, false);
+  assert.equal(sb.events("blocked").length, 0);
+  sb.close();
+});
+
+test("a request already rerouted to a mock endpoint is never blocked", async () => {
+  const sb = await loadInspector({ mode: "mock", mocks: MOCKS });
+  const e = sb.fire("htmx:beforeRequest", { requestConfig: { verb: "post", path: "/__sb/mock/s/v/1" } });
+  assert.equal(e.defaultPrevented, false);
+  assert.equal(sb.events("blocked").length, 0);
+  sb.close();
+});

--- a/test/ui/package-lock.json
+++ b/test/ui/package-lock.json
@@ -1,0 +1,844 @@
+{
+  "name": "swapbook-ui-tests",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "swapbook-ui-tests",
+      "devDependencies": {
+        "jsdom": "^24"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/test/ui/package.json
+++ b/test/ui/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "swapbook-ui-tests",
+  "private": true,
+  "type": "module",
+  "description": "Dev-only tests for the Swapbook browser UI (jsdom). Not part of the shipped zero-build UI.",
+  "scripts": { "test": "node --test" },
+  "devDependencies": { "jsdom": "^24" }
+}


### PR DESCRIPTION
## Summary
Adds runtime tests for the browser UI in an isolated, dev-only harness, and wires a UI job into CI. The shipped gallery stays a plain `<script>` with no build step; the tests live under `test/ui/` with their own `package.json` (jsdom).

## Changes
- jsdom harness that loads the real `index.html` and `app.js` with a stubbed fetch.
- Chrome tests: adapter ok, "no adapter" (404) vs "target unreachable", and the inspector "ready" line labelling non-htmx probes as beta.
- Inspector gating tests for all four probes (htmx, Turbo, Unpoly, Datastar): mock rerouting, mutation blocking, live passthrough, and mock paths never blocked.
- CI `js` job: `npm ci`, `node --test`, and a `tsc` typecheck of the JSDoc.

## Verify
```
npm --prefix test/ui ci && npm --prefix test/ui test
npx -p typescript tsc -p cmd/swapbook/ui/jsconfig.json
```
