### PR TITLE
feat(adapters): Django, Rails and PHP adapters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,13 @@ jobs:
         run: npm test
       - name: typecheck UI (JSDoc + checkJs)
         run: npx -y -p typescript tsc -p cmd/swapbook/ui/jsconfig.json
+
+  php:
+    name: php adapter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+      - run: php adapters/php/swapbook_test.php

--- a/adapters/django/swapbook_adapter.py
+++ b/adapters/django/swapbook_adapter.py
@@ -1,0 +1,117 @@
+"""Swapbook adapter for Django.
+
+Exposes the Swapbook protocol (manifest / preview / mocks / mock) on your
+Django app. Render-agnostic: a variant is just a callable ``(args) -> str`` that
+returns HTML, so it works with plain templates, django-components, cotton, or
+raw strings, on any modern Django (3.2+). Mount ``registry.urls`` in your
+urlpatterns.
+"""
+import json
+import re
+
+from django.http import HttpResponse, JsonResponse, HttpResponseNotFound
+from django.urls import path
+
+Args = dict  # {control_name: coerced_value}
+
+
+def slug(s: str) -> str:
+    return re.sub(r"-+", "-", re.sub(r"[^a-z0-9]+", "-", s.lower())).strip("-")
+
+
+def control(name, type="text", default=None, options=None):
+    """Declare an editable control (knob). type: text|number|bool|select."""
+    c = {"name": name, "type": type, "default": default}
+    if options:
+        c["options"] = options
+    return c
+
+
+def mock(route, render):
+    """A canned response: route is "VERB /path", render is (args)->str."""
+    verb, _, p = route.partition(" ") if " " in route else ("GET", "", route)
+    return {"verb": verb.upper(), "path": p or route, "render": render}
+
+
+def variant(name, render, controls=None, docs="", mocks=None):
+    """One rendered state. render is a callable (args: dict) -> html str."""
+    return {"name": name, "render": render, "controls": controls or [], "docs": docs, "mocks": mocks or []}
+
+
+def _coerce(controls, GET):
+    args = {}
+    for c in controls:
+        name = c["name"]
+        if name not in GET:  # absent -> default; present-but-empty is a real value
+            args[name] = c.get("default")
+            continue
+        raw = GET.get(name, "")
+        t = c.get("type")
+        if t == "number":
+            try:
+                args[name] = float(raw)
+            except ValueError:
+                args[name] = c.get("default")
+        elif t == "bool":
+            args[name] = raw in ("true", "1", "on")
+        else:
+            args[name] = raw
+    return args
+
+
+class Registry:
+    def __init__(self, htmx_src="", css_src="", js_src=""):
+        self.htmx_src, self.css_src, self.js_src = htmx_src, css_src, js_src
+        self._stories = []
+
+    def register(self, name, variants, group="", docs=""):
+        self._stories.append(
+            {"id": slug(name), "name": name, "group": group, "docs": docs, "variants": variants}
+        )
+
+    def _find(self, sid, vname):
+        for s in self._stories:
+            if s["id"] == sid:
+                for v in s["variants"]:
+                    if v["name"] == vname:
+                        return v
+        return None
+
+    @property
+    def urls(self):
+        return [
+            path("_swapbook/manifest.json", self._manifest),
+            path("_swapbook/preview/<str:sid>/<str:vname>", self._preview),
+            path("_swapbook/mocks/<str:sid>/<str:vname>", self._mocks),
+            path("_swapbook/mock/<str:sid>/<str:vname>/<int:index>", self._mock),
+        ]
+
+    def _manifest(self, request):
+        return JsonResponse({
+            "htmxSrc": self.htmx_src, "cssSrc": self.css_src, "jsSrc": self.js_src,
+            "stories": [{
+                "id": s["id"], "name": s["name"], "group": s["group"], "docs": s["docs"],
+                "variants": [{"name": v["name"], "controls": v["controls"], "docs": v["docs"]} for v in s["variants"]],
+            } for s in self._stories],
+        })
+
+    def _preview(self, request, sid, vname):
+        v = self._find(sid, vname)
+        if not v:
+            return HttpResponseNotFound()
+        return HttpResponse(v["render"](_coerce(v["controls"], request.GET)))
+
+    def _mocks(self, request, sid, vname):
+        v = self._find(sid, vname)
+        if not v:
+            return HttpResponseNotFound()
+        return JsonResponse(
+            [{"verb": m["verb"], "path": m["path"], "index": i} for i, m in enumerate(v["mocks"])],
+            safe=False,
+        )
+
+    def _mock(self, request, sid, vname, index):
+        v = self._find(sid, vname)
+        if not v or index < 0 or index >= len(v["mocks"]):
+            return HttpResponseNotFound()
+        return HttpResponse(v["mocks"][index]["render"]({}))

--- a/adapters/php/swapbook.php
+++ b/adapters/php/swapbook.php
@@ -1,0 +1,123 @@
+<?php
+// Swapbook adapter for Laravel / PHP.
+//
+// Exposes the Swapbook protocol (manifest / preview / mocks / mock). Render-
+// agnostic: a variant's render is a callable(array $args): string returning
+// HTML, so it works with Blade, plain PHP, or any templating. Dispatch requests
+// through Swapbook::handle(); mount point is /_swapbook.
+
+function sb_control(string $name, string $type = 'text', $default = null, ?array $options = null): array
+{
+    $c = ['name' => $name, 'type' => $type, 'default' => $default];
+    if ($options !== null) {
+        $c['options'] = $options;
+    }
+    return $c;
+}
+
+function sb_mock(string $route, callable $render): array
+{
+    [$verb, $path] = str_contains($route, ' ') ? explode(' ', $route, 2) : ['GET', $route];
+    return ['verb' => strtoupper($verb), 'path' => $path, 'render' => $render];
+}
+
+function sb_variant(string $name, callable $render, array $controls = [], string $docs = '', array $mocks = []): array
+{
+    return compact('name', 'render', 'controls', 'docs', 'mocks');
+}
+
+class Swapbook
+{
+    private array $stories = [];
+    public string $htmxSrc = '';
+    public string $cssSrc = '';
+    public string $jsSrc = '';
+
+    public function register(string $name, array $variants, string $group = '', string $docs = ''): void
+    {
+        $this->stories[] = ['id' => self::slug($name), 'name' => $name, 'group' => $group, 'docs' => $docs, 'variants' => $variants];
+    }
+
+    public static function slug(string $s): string
+    {
+        return trim(preg_replace('/-+/', '-', preg_replace('/[^a-z0-9]+/', '-', strtolower($s))), '-');
+    }
+
+    private function find(string $id, string $vname): ?array
+    {
+        foreach ($this->stories as $s) {
+            if ($s['id'] === $id) {
+                foreach ($s['variants'] as $v) {
+                    if ($v['name'] === $vname) {
+                        return $v;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private function coerce(array $controls, array $q): array
+    {
+        $args = [];
+        foreach ($controls as $c) {
+            $n = $c['name'];
+            if (!array_key_exists($n, $q)) { // absent -> default; empty is a real value
+                $args[$n] = $c['default'] ?? null;
+                continue;
+            }
+            $raw = (string) $q[$n];
+            $args[$n] = match ($c['type']) {
+                'number' => is_numeric($raw) ? (float) $raw : ($c['default'] ?? 0),
+                'bool' => in_array($raw, ['true', '1', 'on'], true),
+                default => $raw,
+            };
+        }
+        return $args;
+    }
+
+    /** @return array{0:int,1:string,2:string} [status, contentType, body] */
+    public function handle(string $method, string $path, array $query): array
+    {
+        if ($path === '/_swapbook/manifest.json') {
+            return $this->json($this->manifest());
+        }
+        if (preg_match('#^/_swapbook/preview/([^/]+)/([^/]+)$#', $path, $m)) {
+            $v = $this->find($m[1], $m[2]);
+            return $v ? $this->html(($v['render'])($this->coerce($v['controls'], $query))) : $this->notFound();
+        }
+        if (preg_match('#^/_swapbook/mocks/([^/]+)/([^/]+)$#', $path, $m)) {
+            $v = $this->find($m[1], $m[2]);
+            if (!$v) {
+                return $this->notFound();
+            }
+            $out = [];
+            foreach ($v['mocks'] as $i => $mk) {
+                $out[] = ['verb' => $mk['verb'], 'path' => $mk['path'], 'index' => $i];
+            }
+            return $this->json($out);
+        }
+        if (preg_match('#^/_swapbook/mock/([^/]+)/([^/]+)/(\d+)$#', $path, $m)) {
+            $v = $this->find($m[1], $m[2]);
+            return ($v && isset($v['mocks'][(int) $m[3]]))
+                ? $this->html(($v['mocks'][(int) $m[3]]['render'])([]))
+                : $this->notFound();
+        }
+        return $this->notFound();
+    }
+
+    private function manifest(): array
+    {
+        return [
+            'htmxSrc' => $this->htmxSrc, 'cssSrc' => $this->cssSrc, 'jsSrc' => $this->jsSrc,
+            'stories' => array_map(fn($s) => [
+                'id' => $s['id'], 'name' => $s['name'], 'group' => $s['group'], 'docs' => $s['docs'],
+                'variants' => array_map(fn($v) => ['name' => $v['name'], 'controls' => $v['controls'], 'docs' => $v['docs']], $s['variants']),
+            ], $this->stories),
+        ];
+    }
+
+    private function json(array $o): array { return [200, 'application/json', json_encode($o)]; }
+    private function html(string $s): array { return [200, 'text/html; charset=utf-8', $s]; }
+    private function notFound(): array { return [404, 'text/plain', 'not found']; }
+}

--- a/adapters/php/swapbook_test.php
+++ b/adapters/php/swapbook_test.php
@@ -1,0 +1,75 @@
+<?php
+// Unit test for the PHP/Laravel Swapbook adapter. No framework needed:
+//   php adapters/php/swapbook_test.php
+// or, without a local PHP:
+//   docker run --rm -v "$PWD/adapters/php:/app" -w /app php:8.3-cli php swapbook_test.php
+require __DIR__ . '/swapbook.php';
+
+$fails = 0;
+function check(bool $ok, string $msg): void
+{
+    global $fails;
+    echo ($ok ? "  ok   " : "  FAIL ") . $msg . "\n";
+    if (!$ok) {
+        $fails++;
+    }
+}
+
+$sb = new Swapbook();
+$sb->cssSrc = '/static/ds.css';
+$sb->register('Button', [
+    sb_variant('primary', fn($a) => '<button>Save</button>'),
+    sb_variant('controls', fn($a) => "label={$a['label']} n={$a['reviews']} b=" . ($a['disabled'] ? '1' : '0'), [
+        sb_control('label', 'text', 'Save'),
+        sb_control('reviews', 'number', 0),
+        sb_control('disabled', 'bool', false),
+    ]),
+], 'actions', 'Button docs.');
+$sb->register('Todo', [
+    sb_variant('default', fn($a) => '<ul id="rows"></ul>', [], 'todo docs', [
+        sb_mock('GET /ds/row', fn($a) => '<li>New task</li>'),
+    ]),
+], 'interactive');
+
+// slug normalization
+check(Swapbook::slug('PR Card') === 'pr-card', 'slug("PR Card") == pr-card');
+
+// manifest
+[$st, $ct, $body] = $sb->handle('GET', '/_swapbook/manifest.json', []);
+check($st === 200, 'manifest 200');
+check($ct === 'application/json', 'manifest content-type json');
+$m = json_decode($body, true);
+check(($m['cssSrc'] ?? null) === '/static/ds.css', 'manifest cssSrc');
+check(count($m['stories']) === 2, 'manifest 2 stories');
+check(($m['stories'][0]['id'] ?? null) === 'button', 'story id slugged');
+$ctrl = $m['stories'][0]['variants'][1] ?? [];
+check(($ctrl['name'] ?? null) === 'controls' && ($ctrl['controls'][0]['name'] ?? null) === 'label', 'control schema in manifest');
+
+// preview: static variant
+[$st, , $body] = $sb->handle('GET', '/_swapbook/preview/button/primary', []);
+check($st === 200 && $body === '<button>Save</button>', 'preview static variant');
+
+// preview: control coercion (text + number, absent bool -> default false)
+[, , $body] = $sb->handle('GET', '/_swapbook/preview/button/controls', ['label' => 'Hi', 'reviews' => '3']);
+check($body === 'label=Hi n=3 b=0', "coerce text+number, absent bool default: got '$body'");
+// preview: bool coercion + remaining defaults
+[, , $body] = $sb->handle('GET', '/_swapbook/preview/button/controls', ['disabled' => 'true']);
+check($body === 'label=Save n=0 b=1', "coerce bool true + defaults: got '$body'");
+
+// mocks list
+[$st, , $body] = $sb->handle('GET', '/_swapbook/mocks/todo/default', []);
+$mk = json_decode($body, true);
+check($st === 200 && ($mk[0]['verb'] ?? '') === 'GET' && ($mk[0]['path'] ?? '') === '/ds/row' && ($mk[0]['index'] ?? -1) === 0, 'mocks list shape');
+
+// mock render (any method)
+[$st, , $body] = $sb->handle('POST', '/_swapbook/mock/todo/default/0', []);
+check($st === 200 && $body === '<li>New task</li>', 'mock render');
+
+// unknown routes -> 404
+[$st] = $sb->handle('GET', '/_swapbook/preview/nope/nope', []);
+check($st === 404, 'unknown preview 404');
+[$st] = $sb->handle('GET', '/nope', []);
+check($st === 404, 'non-swapbook path 404');
+
+echo $fails === 0 ? "\nPHP ADAPTER: ALL PASS\n" : "\nPHP ADAPTER: $fails FAILED\n";
+exit($fails === 0 ? 0 : 1);

--- a/adapters/rails/swapbook.rb
+++ b/adapters/rails/swapbook.rb
@@ -1,0 +1,99 @@
+# Swapbook adapter for Rails (and any Rack app).
+#
+# A Rack app exposing the Swapbook protocol (manifest / preview / mocks / mock).
+# Render-agnostic: a variant's :render is a proc (args) -> HTML string, so it
+# works with ActionView partials, ViewComponent, Phlex or raw strings, on any
+# modern Rails (6+). Mount it:  mount registry => "/_swapbook"
+require "json"
+require "rack"
+
+module Swapbook
+  def self.slug(s)
+    s.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/-+/, "-").gsub(/\A-|-\z/, "")
+  end
+
+  def self.control(name, type: "text", default: nil, options: nil)
+    { name: name, type: type, default: default, options: options }.compact
+  end
+
+  def self.mock(route, render)
+    verb, path = route.include?(" ") ? route.split(" ", 2) : ["GET", route]
+    { verb: verb.upcase, path: path, render: render }
+  end
+
+  def self.variant(name, render, controls: [], docs: "", mocks: [])
+    { name: name, render: render, controls: controls, docs: docs, mocks: mocks }
+  end
+
+  class Registry
+    def initialize(htmx_src: "", css_src: "", js_src: "")
+      @htmx_src, @css_src, @js_src = htmx_src, css_src, js_src
+      @stories = []
+    end
+
+    def register(name, variants:, group: "", docs: "")
+      @stories << { id: Swapbook.slug(name), name: name, group: group, docs: docs, variants: variants }
+    end
+
+    # Rack entry point (PATH_INFO is relative to the mount point).
+    def call(env)
+      path = env["PATH_INFO"]
+      params = Rack::Request.new(env).params
+      case path
+      when "/manifest.json"
+        json(manifest)
+      when %r{\A/preview/([^/]+)/([^/]+)\z}
+        v = find($1, $2)
+        v ? html(v[:render].call(coerce(v[:controls], params))) : not_found
+      when %r{\A/mocks/([^/]+)/([^/]+)\z}
+        v = find($1, $2)
+        v ? json(v[:mocks].each_with_index.map { |m, i| { verb: m[:verb], path: m[:path], index: i } }) : not_found
+      when %r{\A/mock/([^/]+)/([^/]+)/(\d+)\z}
+        v = find($1, $2)
+        (v && v[:mocks][$3.to_i]) ? html(v[:mocks][$3.to_i][:render].call({})) : not_found
+      else
+        not_found
+      end
+    end
+
+    private
+
+    def manifest
+      {
+        htmxSrc: @htmx_src, cssSrc: @css_src, jsSrc: @js_src,
+        stories: @stories.map { |s|
+          {
+            id: s[:id], name: s[:name], group: s[:group], docs: s[:docs],
+            variants: s[:variants].map { |v| { name: v[:name], controls: v[:controls], docs: v[:docs] } },
+          }
+        },
+      }
+    end
+
+    def find(sid, vname)
+      s = @stories.find { |st| st[:id] == sid }
+      s && s[:variants].find { |v| v[:name] == vname }
+    end
+
+    def coerce(controls, params)
+      controls.each_with_object({}) do |c, args|
+        name = c[:name]
+        unless params.key?(name) # absent -> default; present-but-empty is real
+          args[name] = c[:default]
+          next
+        end
+        raw = params[name].to_s
+        args[name] =
+          case c[:type]
+          when "number" then (Float(raw) rescue c[:default])
+          when "bool" then %w[true 1 on].include?(raw)
+          else raw
+          end
+      end
+    end
+
+    def json(obj) = [200, { "content-type" => "application/json" }, [JSON.generate(obj)]]
+    def html(str) = [200, { "content-type" => "text/html; charset=utf-8" }, [str.to_s]]
+    def not_found = [404, { "content-type" => "text/plain" }, ["not found"]]
+  end
+end


### PR DESCRIPTION
## Summary
Ready-made Swapbook adapters for three more stacks. Each is render-agnostic: a variant is a callable returning an HTML string, so it works with the stack's own templating (Django templates, ActionView / ViewComponent / Phlex, Blade) and across framework versions (Django 3.2+, Rails 6+).

## Changes
- `adapters/django/swapbook_adapter.py`: `Registry` + `registry.urls`.
- `adapters/rails/swapbook.rb`: Rack app, `mount REG => "/_swapbook"`.
- `adapters/php/swapbook.php`: `Swapbook` class + `sb_variant` / `sb_control` / `sb_mock`.
- PHP adapter unit test (14 checks) and a CI `php` job on PHP 8.3.

## Verify
```
php adapters/php/swapbook_test.php   # PHP ADAPTER: ALL PASS
```
