### PR TITLE
feat(examples): shared demo design system across stacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
-          cache: true
+          cache: false
       - name: gofmt
         run: |
           unformatted=$(gofmt -l .)
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: stable
-          cache: true
+          cache: false
       - uses: golangci/golangci-lint-action@v7
         with:
           version: latest
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: stable
-          cache: true
+          cache: false
       - uses: actions/setup-node@v4
         with:
           node-version: "20"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,4 +93,5 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.2"
+      - run: gem install webrick --no-document # dropped from Ruby's default gems in 3.0
       - run: bash examples/smoke.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,20 @@ jobs:
         with:
           php-version: "8.3"
       - run: php adapters/php/swapbook_test.php
+
+  smoke:
+    name: protocol smoke (python/node/ruby)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+      - run: bash examples/smoke.sh

--- a/examples/django/app.py
+++ b/examples/django/app.py
@@ -1,0 +1,150 @@
+"""Single-file Django app demoing the Swapbook adapter: no project scaffold,
+just inline settings, the shared demo design system rendered from real Django
+templates, the adapter mounted, and the dev server. Same component set as the
+Go, Rails and Laravel demos so the gallery looks identical across stacks."""
+import os
+import sys
+
+import django
+from django.conf import settings
+
+settings.configure(
+    DEBUG=True,
+    ALLOWED_HOSTS=["*"],
+    SECRET_KEY="swapbook-demo",
+    ROOT_URLCONF=__name__,
+    TEMPLATES=[{"BACKEND": "django.template.backends.django.DjangoTemplates", "DIRS": [], "APP_DIRS": False, "OPTIONS": {}}],
+    INSTALLED_APPS=[],
+)
+django.setup()
+
+from django.http import HttpResponse  # noqa: E402
+from django.template import Context, Template  # noqa: E402
+from django.urls import path  # noqa: E402
+from swapbook_adapter import Registry, control, mock, variant  # noqa: E402
+
+
+def T(src):
+    tpl = Template(src)
+    return lambda ctx=None: tpl.render(Context(ctx or {}))
+
+
+# Each component is a real Django template; args map straight onto the context.
+btn = T('<button class="btn btn-{{ variant }} btn-{{ size }}"{% if disabled %} disabled{% endif %}>{{ label }}</button>')
+badge = T('<span class="badge badge-{{ status }}">{{ label }}</span>')
+alert = T('<div class="alert alert-{{ kind }}">{{ msg }}</div>')
+card = T('<div class="card"><div class="card-head"><strong>{{ title }}</strong><span class="badge badge-{{ status }}">{{ status }}</span></div>{% if reviews %}<p class="muted">{{ reviews }} review{{ reviews|pluralize }}</p>{% endif %}</div>')
+field = T('<div class="field{% if error %} error{% endif %}"><label>{{ label }}</label><input value="{{ value }}" placeholder="{{ label }}"{% if disabled %} disabled{% endif %}>{% if error %}<span class="err">{{ error }}</span>{% endif %}</div>')
+empty = T('<div class="empty"><div class="mark">📭</div><h4>{{ title }}</h4><div>{{ hint }}</div></div>')
+table = T('<table class="ds"><thead><tr><th>name</th><th>role</th><th>status</th></tr></thead><tbody>{% for r in rows %}<tr><td>{{ r.name }}</td><td>{{ r.role }}</td><td><span class="badge badge-{{ r.status }}">{{ r.status }}</span></td></tr>{% endfor %}</tbody></table>')
+todo = T('<div class="todo"><ul id="rows"><li>Write the launch post</li><li>Record the demo gif</li></ul><button class="btn btn-secondary" hx-get="/ds/row" hx-target="#rows" hx-swap="beforeend">+ add row</button></div>')
+phantom_t = T('<script src="https://cdn.jsdelivr.net/npm/@aejkatappaja/phantom-ui/dist/phantom-ui.cdn.js"></script><phantom-ui{% if loading %} loading{% endif %} animation="{{ animation }}" style="display:block;max-width:420px"><div class="card"><div class="card-head"><strong>Ada Lovelace</strong></div><p class="muted">First programmer, probably.</p></div></phantom-ui>')
+
+
+def phantom(a):
+    return phantom_t({"loading": a.get("loading", True), "animation": a.get("animation", "shimmer")})
+
+
+reg = Registry(css_src="/static/ds.css")  # htmx_src empty -> Swapbook's embedded htmx
+
+reg.register("Button", group="actions", docs="The button primitive. `variant` and `size` are props, not classes you type.", variants=[
+    variant("primary", lambda a: btn({"label": "Save", "variant": "primary", "size": "md"})),
+    variant("secondary", lambda a: btn({"label": "Cancel", "variant": "secondary", "size": "md"})),
+    variant("danger", lambda a: btn({"label": "Delete", "variant": "danger", "size": "md"})),
+    variant("disabled", lambda a: btn({"label": "Save", "variant": "primary", "size": "md", "disabled": True})),
+    variant("controls", lambda a: btn({"label": a["label"], "variant": a["variant"], "size": a["size"], "disabled": a["disabled"]}), controls=[
+        control("label", "text", "Save"),
+        control("variant", "select", "primary", options=["primary", "secondary", "danger"]),
+        control("size", "select", "md", options=["sm", "md", "lg"]),
+        control("disabled", "bool", False),
+    ]),
+])
+
+reg.register("Badge", group="data-display", variants=[
+    variant("open", lambda a: badge({"status": "open", "label": "open"})),
+    variant("merged", lambda a: badge({"status": "merged", "label": "merged"})),
+    variant("closed", lambda a: badge({"status": "closed", "label": "closed"})),
+    variant("controls", lambda a: badge({"status": a["status"], "label": a["label"]}), controls=[
+        control("status", "select", "open", options=["open", "merged", "closed"]),
+        control("label", "text", "open"),
+    ]),
+])
+
+reg.register("Alert", group="feedback", variants=[
+    variant("info", lambda a: alert({"kind": "info", "msg": "A new version is available."})),
+    variant("success", lambda a: alert({"kind": "success", "msg": "Saved successfully."})),
+    variant("warning", lambda a: alert({"kind": "warning", "msg": "Your trial ends in 3 days."})),
+    variant("error", lambda a: alert({"kind": "error", "msg": "Could not reach the server."})),
+    variant("controls", lambda a: alert({"kind": a["kind"], "msg": a["message"]}), controls=[
+        control("kind", "select", "info", options=["info", "success", "warning", "error"]),
+        control("message", "text", "Heads up."),
+    ]),
+])
+
+reg.register("PR Card", group="data-display", variants=[
+    variant("open", lambda a: card({"title": "Add dark mode", "status": "open", "reviews": 0})),
+    variant("with-reviews", lambda a: card({"title": "Refactor router", "status": "merged", "reviews": 3})),
+    variant("controls", lambda a: card({"title": a["title"], "status": a["status"], "reviews": int(a["reviews"] or 0)}), controls=[
+        control("title", "text", "Add dark mode"),
+        control("status", "select", "open", options=["open", "merged", "closed"]),
+        control("reviews", "number", 0),
+    ]),
+])
+
+reg.register("Field", group="forms", variants=[
+    variant("default", lambda a: field({"label": "Email", "value": ""})),
+    variant("error", lambda a: field({"label": "Email", "value": "not-an-email", "error": "Enter a valid email"})),
+    variant("disabled", lambda a: field({"label": "Email", "value": "you@example.com", "disabled": True})),
+    variant("controls", lambda a: field({"label": a["label"], "value": a["value"], "error": a["error"], "disabled": a["disabled"]}), controls=[
+        control("label", "text", "Email"),
+        control("value", "text", ""),
+        control("error", "text", ""),
+        control("disabled", "bool", False),
+    ]),
+])
+
+reg.register("Empty state", group="feedback", variants=[
+    variant("default", lambda a: empty({"title": a["title"], "hint": a["hint"]}), controls=[
+        control("title", "text", "No workouts yet"),
+        control("hint", "text", "Create your first one to get started."),
+    ]),
+])
+
+reg.register("Table", group="data-display", variants=[
+    variant("default", lambda a: table({"rows": [
+        {"name": "Ada Lovelace", "role": "Owner", "status": "open"},
+        {"name": "Alan Turing", "role": "Maintainer", "status": "merged"},
+        {"name": "Grace Hopper", "role": "Contributor", "status": "closed"},
+    ]})),
+])
+
+reg.register("Todo list", group="interactive", variants=[
+    variant("default", lambda a: todo(),
+            docs="Click **+ add row**: the mock returns a new `<li>` htmx appends. Watch the swap-target flash in the inspector.",
+            mocks=[mock("GET /ds/row", lambda a: "<li>New task</li>")]),
+])
+
+reg.register("Skeleton (phantom-ui)", group="web components", docs="A third-party **Web Component** (`@aejkatappaja/phantom-ui`) from jsdelivr. Toggle `loading` to swap skeleton and content.", variants=[
+    variant("loading", phantom),
+    variant("loaded", lambda a: phantom({"loading": False})),
+    variant("controls", phantom, controls=[
+        control("loading", "bool", True),
+        control("animation", "select", "shimmer", options=["shimmer", "pulse", "breathe", "solid"]),
+    ]),
+])
+
+
+def _ds_css(request):
+    for cand in (os.path.join(os.path.dirname(__file__), "ds.css"), "examples/shared/ds.css"):
+        if os.path.exists(cand):
+            with open(cand, encoding="utf-8") as f:
+                return HttpResponse(f.read(), content_type="text/css; charset=utf-8")
+    return HttpResponse(status=404)
+
+
+urlpatterns = reg.urls + [path("static/ds.css", _ds_css)]
+
+if __name__ == "__main__":
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line([sys.argv[0], "runserver", "0.0.0.0:8000", "--noreload"])

--- a/examples/go/main.go
+++ b/examples/go/main.go
@@ -1,0 +1,179 @@
+// Reference Swapbook demo for Go: the shared demo design system, rendered with
+// stdlib html/template (no codegen, so `go run ./examples/go` just works). The
+// go-gym project is the templ showcase; this is the self-contained example.
+package main
+
+import (
+	"context"
+	"flag"
+	"html/template"
+	"io"
+	"log"
+	"net/http"
+	"os"
+
+	adapter "github.com/Aejkatappaja/swapbook/adapters/go"
+)
+
+func tmpl(s string) *template.Template { return template.Must(template.New("c").Parse(s)) }
+
+// render wraps an html/template execution as an adapter.Renderer.
+func render(t *template.Template, data any) adapter.Renderer {
+	return adapter.RenderFunc(func(_ context.Context, w io.Writer) error { return t.Execute(w, data) })
+}
+
+var (
+	btnT   = tmpl(`<button class="btn btn-{{.Variant}} btn-{{.Size}}"{{if .Disabled}} disabled{{end}}>{{.Label}}</button>`)
+	badgeT = tmpl(`<span class="badge badge-{{.Status}}">{{.Label}}</span>`)
+	alertT = tmpl(`<div class="alert alert-{{.Kind}}">{{.Msg}}</div>`)
+	cardT  = tmpl(`<div class="card"><div class="card-head"><strong>{{.Title}}</strong><span class="badge badge-{{.Status}}">{{.Status}}</span></div>{{if .Reviews}}<p class="muted">{{.Reviews}} review{{if ne .Reviews 1}}s{{end}}</p>{{end}}</div>`)
+	fieldT = tmpl(`<div class="field{{if .Error}} error{{end}}"><label>{{.Label}}</label><input value="{{.Value}}" placeholder="{{.Label}}"{{if .Disabled}} disabled{{end}}>{{if .Error}}<span class="err">{{.Error}}</span>{{end}}</div>`)
+	emptyT = tmpl(`<div class="empty"><div class="mark">📭</div><h4>{{.Title}}</h4><div>{{.Hint}}</div></div>`)
+	tableT = tmpl(`<table class="ds"><thead><tr><th>name</th><th>role</th><th>status</th></tr></thead><tbody>{{range .}}<tr><td>{{.Name}}</td><td>{{.Role}}</td><td><span class="badge badge-{{.Status}}">{{.Status}}</span></td></tr>{{end}}</tbody></table>`)
+	todoT  = tmpl(`<div class="todo"><ul id="rows"><li>Write the launch post</li><li>Record the demo gif</li></ul><button class="btn btn-secondary" hx-get="/ds/row" hx-target="#rows" hx-swap="beforeend">+ add row</button></div>`)
+	rowT   = tmpl(`<li>New task</li>`)
+	phanT  = tmpl(`<script src="https://cdn.jsdelivr.net/npm/@aejkatappaja/phantom-ui/dist/phantom-ui.cdn.js"></script><phantom-ui{{if .Loading}} loading{{end}} animation="{{.Animation}}" style="display:block;max-width:420px"><div class="card"><div class="card-head"><strong>Ada Lovelace</strong></div><p class="muted">First programmer, probably.</p></div></phantom-ui>`)
+)
+
+type row struct{ Name, Role, Status string }
+
+func btn(label, variant, size string, disabled bool) adapter.Renderer {
+	return render(btnT, map[string]any{"Label": label, "Variant": variant, "Size": size, "Disabled": disabled})
+}
+func card(title, status string, reviews int) adapter.Renderer {
+	return render(cardT, map[string]any{"Title": title, "Status": status, "Reviews": reviews})
+}
+func phantom(loading bool, anim string) adapter.Renderer {
+	return render(phanT, map[string]any{"Loading": loading, "Animation": anim})
+}
+
+func registry() *adapter.Registry {
+	reg := adapter.New()
+	reg.CSSSrc = "/static/ds.css"
+
+	reg.RegisterIn("actions", "Button",
+		adapter.Var("primary", btn("Save", "primary", "md", false)),
+		adapter.Var("secondary", btn("Cancel", "secondary", "md", false)),
+		adapter.Var("danger", btn("Delete", "danger", "md", false)),
+		adapter.Var("disabled", btn("Save", "primary", "md", true)),
+		adapter.VarC("controls", []adapter.Control{
+			{Name: "label", Type: "text", Default: "Save"},
+			{Name: "variant", Type: "select", Default: "primary", Options: []string{"primary", "secondary", "danger"}},
+			{Name: "size", Type: "select", Default: "md", Options: []string{"sm", "md", "lg"}},
+			{Name: "disabled", Type: "bool", Default: false},
+		}, func(a adapter.Args) adapter.Renderer {
+			return btn(a.String("label"), a.String("variant"), a.String("size"), a.Bool("disabled"))
+		}),
+	)
+	reg.DocStory("Button", "The button primitive. `variant` and `size` are props, not classes you type.")
+
+	reg.RegisterIn("data-display", "Badge",
+		adapter.Var("open", render(badgeT, map[string]any{"Status": "open", "Label": "open"})),
+		adapter.Var("merged", render(badgeT, map[string]any{"Status": "merged", "Label": "merged"})),
+		adapter.Var("closed", render(badgeT, map[string]any{"Status": "closed", "Label": "closed"})),
+		adapter.VarC("controls", []adapter.Control{
+			{Name: "status", Type: "select", Default: "open", Options: []string{"open", "merged", "closed"}},
+			{Name: "label", Type: "text", Default: "open"},
+		}, func(a adapter.Args) adapter.Renderer {
+			return render(badgeT, map[string]any{"Status": a.String("status"), "Label": a.String("label")})
+		}),
+	)
+
+	reg.RegisterIn("feedback", "Alert",
+		adapter.Var("info", render(alertT, map[string]any{"Kind": "info", "Msg": "A new version is available."})),
+		adapter.Var("success", render(alertT, map[string]any{"Kind": "success", "Msg": "Saved successfully."})),
+		adapter.Var("warning", render(alertT, map[string]any{"Kind": "warning", "Msg": "Your trial ends in 3 days."})),
+		adapter.Var("error", render(alertT, map[string]any{"Kind": "error", "Msg": "Could not reach the server."})),
+		adapter.VarC("controls", []adapter.Control{
+			{Name: "kind", Type: "select", Default: "info", Options: []string{"info", "success", "warning", "error"}},
+			{Name: "message", Type: "text", Default: "Heads up."},
+		}, func(a adapter.Args) adapter.Renderer {
+			return render(alertT, map[string]any{"Kind": a.String("kind"), "Msg": a.String("message")})
+		}),
+	)
+
+	reg.RegisterIn("data-display", "PR Card",
+		adapter.Var("open", card("Add dark mode", "open", 0)),
+		adapter.Var("with-reviews", card("Refactor router", "merged", 3)),
+		adapter.VarC("controls", []adapter.Control{
+			{Name: "title", Type: "text", Default: "Add dark mode"},
+			{Name: "status", Type: "select", Default: "open", Options: []string{"open", "merged", "closed"}},
+			{Name: "reviews", Type: "number", Default: 0},
+		}, func(a adapter.Args) adapter.Renderer {
+			return card(a.String("title"), a.String("status"), a.Int("reviews"))
+		}),
+	)
+
+	reg.RegisterIn("forms", "Field",
+		adapter.Var("default", render(fieldT, map[string]any{"Label": "Email", "Value": ""})),
+		adapter.Var("error", render(fieldT, map[string]any{"Label": "Email", "Value": "not-an-email", "Error": "Enter a valid email"})),
+		adapter.Var("disabled", render(fieldT, map[string]any{"Label": "Email", "Value": "you@example.com", "Disabled": true})),
+		adapter.VarC("controls", []adapter.Control{
+			{Name: "label", Type: "text", Default: "Email"},
+			{Name: "value", Type: "text", Default: ""},
+			{Name: "error", Type: "text", Default: ""},
+			{Name: "disabled", Type: "bool", Default: false},
+		}, func(a adapter.Args) adapter.Renderer {
+			return render(fieldT, map[string]any{"Label": a.String("label"), "Value": a.String("value"), "Error": a.String("error"), "Disabled": a.Bool("disabled")})
+		}),
+	)
+
+	reg.RegisterIn("feedback", "Empty state",
+		adapter.VarC("default", []adapter.Control{
+			{Name: "title", Type: "text", Default: "No workouts yet"},
+			{Name: "hint", Type: "text", Default: "Create your first one to get started."},
+		}, func(a adapter.Args) adapter.Renderer {
+			return render(emptyT, map[string]any{"Title": a.String("title"), "Hint": a.String("hint")})
+		}),
+	)
+
+	reg.RegisterIn("data-display", "Table",
+		adapter.Var("default", render(tableT, []row{
+			{"Ada Lovelace", "Owner", "open"},
+			{"Alan Turing", "Maintainer", "merged"},
+			{"Grace Hopper", "Contributor", "closed"},
+		})),
+	)
+
+	reg.RegisterIn("interactive", "Todo list",
+		adapter.Var("default", render(todoT, nil)).
+			Mock("GET /ds/row", render(rowT, nil)).
+			Doc("Click **+ add row**: the mock returns a new `<li>` htmx appends. Watch the swap-target flash in the inspector."),
+	)
+
+	reg.RegisterIn("web components", "Skeleton (phantom-ui)",
+		adapter.Var("loading", phantom(true, "shimmer")),
+		adapter.Var("loaded", phantom(false, "shimmer")),
+		adapter.VarC("controls", []adapter.Control{
+			{Name: "loading", Type: "bool", Default: true},
+			{Name: "animation", Type: "select", Default: "shimmer", Options: []string{"shimmer", "pulse", "breathe", "solid"}},
+		}, func(a adapter.Args) adapter.Renderer {
+			return phantom(a.Bool("loading"), a.String("animation"))
+		}),
+	)
+	reg.DocStory("Skeleton (phantom-ui)", "A third-party **Web Component** (`@aejkatappaja/phantom-ui`) from jsdelivr. Toggle `loading` to swap skeleton and content.")
+
+	return reg
+}
+
+func main() {
+	port := flag.String("port", "8000", "port to listen on")
+	cssPath := flag.String("css", "examples/shared/ds.css", "path to the shared demo stylesheet")
+	flag.Parse()
+
+	dsCSS, err := os.ReadFile(*cssPath)
+	if err != nil {
+		log.Fatalf("read css %q: %v", *cssPath, err)
+	}
+
+	reg := registry()
+	mux := http.NewServeMux()
+	mux.Handle(adapter.MountPath+"/", http.StripPrefix(adapter.MountPath, reg.Handler()))
+	mux.HandleFunc("/static/ds.css", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/css; charset=utf-8")
+		w.Write(dsCSS)
+	})
+	addr := ":" + *port
+	log.Println("demo target on " + addr)
+	log.Fatal(http.ListenAndServe(addr, mux))
+}

--- a/examples/laravel/composer.json
+++ b/examples/laravel/composer.json
@@ -1,0 +1,5 @@
+{
+  "require": {
+    "illuminate/view": "^11.0"
+  }
+}

--- a/examples/laravel/server.php
+++ b/examples/laravel/server.php
@@ -1,0 +1,165 @@
+<?php
+// Laravel/Blade demo target for Swapbook. Renders the shared demo design system
+// through the real Blade compiler (illuminate/view). Served by php's built-in
+// server as a router script.
+require __DIR__ . '/vendor/autoload.php';
+require __DIR__ . '/swapbook.php';
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\Compilers\BladeCompiler;
+
+/** Render a Blade string with data (the actual Laravel Blade compiler). */
+function blade(string $tpl, array $data = []): string
+{
+    static $compiler;
+    if (!$compiler) {
+        $cache = sys_get_temp_dir() . '/sb-blade';
+        @mkdir($cache);
+        $compiler = new BladeCompiler(new Filesystem(), $cache);
+    }
+    $php = $compiler->compileString($tpl);
+    $level = ob_get_level();
+    ob_start();
+    extract($data);
+    try {
+        eval('?>' . $php);
+    } catch (\Throwable $e) {
+        while (ob_get_level() > $level) {
+            ob_end_clean();
+        }
+        throw $e;
+    }
+    return ob_get_clean();
+}
+
+$card = fn(array $a) => blade(
+    '<div class="card"><div class="card-head"><strong>{{ $title }}</strong><span class="badge badge-{{ $status }}">{{ $status }}</span></div>@if($reviews)<p class="muted">{{ $reviews }} review{{ $reviews == 1 ? "" : "s" }}</p>@endif</div>',
+    ['title' => $a['title'] ?? 'Add dark mode', 'status' => $a['status'] ?? 'open', 'reviews' => (int) ($a['reviews'] ?? 0)]
+);
+$phantom = fn(array $a) => blade(
+    '<script src="https://cdn.jsdelivr.net/npm/@aejkatappaja/phantom-ui/dist/phantom-ui.cdn.js"></script><phantom-ui @if($loading) loading @endif animation="{{ $animation }}" style="display:block;max-width:420px"><div class="card"><div class="card-head"><strong>Ada Lovelace</strong></div><p class="muted">First programmer, probably.</p></div></phantom-ui>',
+    ['loading' => $a['loading'] ?? true, 'animation' => $a['animation'] ?? 'shimmer']
+);
+$btn = fn(array $a) => blade(
+    '<button class="btn btn-{{ $variant }} btn-{{ $size }}" @if($disabled) disabled @endif>{{ $label }}</button>',
+    ['label' => $a['label'] ?? 'Save', 'variant' => $a['variant'] ?? 'primary', 'size' => $a['size'] ?? 'md', 'disabled' => $a['disabled'] ?? false]
+);
+$field = fn(array $a) => blade(
+    '<div class="field @if($error) error @endif"><label>{{ $label }}</label><input value="{{ $value }}" placeholder="{{ $label }}" @if($disabled) disabled @endif>@if($error)<span class="err">{{ $error }}</span>@endif</div>',
+    ['label' => $a['label'] ?? 'Email', 'value' => $a['value'] ?? '', 'error' => $a['error'] ?? '', 'disabled' => $a['disabled'] ?? false]
+);
+$alert = fn(array $a) => blade('<div class="alert alert-{{ $kind }}">{{ $msg }}</div>', ['kind' => $a['kind'] ?? 'info', 'msg' => $a['message'] ?? 'Heads up.']);
+$badge = fn(array $a) => blade('<span class="badge badge-{{ $status }}">{{ $label }}</span>', ['status' => $a['status'] ?? 'open', 'label' => $a['label'] ?? 'open']);
+$empty = fn(array $a) => blade('<div class="empty"><div class="mark">📭</div><h4>{{ $title }}</h4><div>{{ $hint }}</div></div>', ['title' => $a['title'] ?? 'No workouts yet', 'hint' => $a['hint'] ?? 'Create your first one to get started.']);
+
+$sb = new Swapbook();
+$sb->cssSrc = '/static/ds.css';
+
+$sb->register('Button', [
+    sb_variant('primary', fn($a) => $btn(['label' => 'Save', 'variant' => 'primary'])),
+    sb_variant('secondary', fn($a) => $btn(['label' => 'Cancel', 'variant' => 'secondary'])),
+    sb_variant('danger', fn($a) => $btn(['label' => 'Delete', 'variant' => 'danger'])),
+    sb_variant('disabled', fn($a) => $btn(['label' => 'Save', 'disabled' => true])),
+    sb_variant('controls', $btn, [
+        sb_control('label', 'text', 'Save'),
+        sb_control('variant', 'select', 'primary', ['primary', 'secondary', 'danger']),
+        sb_control('size', 'select', 'md', ['sm', 'md', 'lg']),
+        sb_control('disabled', 'bool', false),
+    ]),
+], 'actions', 'The button primitive. `variant` and `size` are props.');
+
+$sb->register('Badge', [
+    sb_variant('open', fn($a) => $badge(['status' => 'open', 'label' => 'open'])),
+    sb_variant('merged', fn($a) => $badge(['status' => 'merged', 'label' => 'merged'])),
+    sb_variant('closed', fn($a) => $badge(['status' => 'closed', 'label' => 'closed'])),
+    sb_variant('controls', $badge, [
+        sb_control('status', 'select', 'open', ['open', 'merged', 'closed']),
+        sb_control('label', 'text', 'open'),
+    ]),
+], 'data-display');
+
+$sb->register('Alert', [
+    sb_variant('info', fn($a) => $alert(['kind' => 'info', 'message' => 'A new version is available.'])),
+    sb_variant('success', fn($a) => $alert(['kind' => 'success', 'message' => 'Saved successfully.'])),
+    sb_variant('warning', fn($a) => $alert(['kind' => 'warning', 'message' => 'Your trial ends in 3 days.'])),
+    sb_variant('error', fn($a) => $alert(['kind' => 'error', 'message' => 'Could not reach the server.'])),
+    sb_variant('controls', $alert, [
+        sb_control('kind', 'select', 'info', ['info', 'success', 'warning', 'error']),
+        sb_control('message', 'text', 'Heads up.'),
+    ]),
+], 'feedback');
+
+$sb->register('PR Card', [
+    sb_variant('open', fn($a) => $card([])),
+    sb_variant('with-reviews', fn($a) => $card(['title' => 'Refactor router', 'status' => 'merged', 'reviews' => 3])),
+    sb_variant('controls', $card, [
+        sb_control('title', 'text', 'Add dark mode'),
+        sb_control('status', 'select', 'open', ['open', 'merged', 'closed']),
+        sb_control('reviews', 'number', 0),
+    ]),
+], 'data-display');
+
+$sb->register('Field', [
+    sb_variant('default', fn($a) => $field(['label' => 'Email'])),
+    sb_variant('error', fn($a) => $field(['label' => 'Email', 'value' => 'not-an-email', 'error' => 'Enter a valid email'])),
+    sb_variant('disabled', fn($a) => $field(['label' => 'Email', 'value' => 'you@example.com', 'disabled' => true])),
+    sb_variant('controls', $field, [
+        sb_control('label', 'text', 'Email'),
+        sb_control('value', 'text', ''),
+        sb_control('error', 'text', ''),
+        sb_control('disabled', 'bool', false),
+    ]),
+], 'forms');
+
+$sb->register('Empty state', [
+    sb_variant('default', $empty, [
+        sb_control('title', 'text', 'No workouts yet'),
+        sb_control('hint', 'text', 'Create your first one to get started.'),
+    ]),
+], 'feedback');
+
+$sb->register('Table', [
+    sb_variant('default', function ($a) {
+        $rows = [
+            ['name' => 'Ada Lovelace', 'role' => 'Owner', 'status' => 'open'],
+            ['name' => 'Alan Turing', 'role' => 'Maintainer', 'status' => 'merged'],
+            ['name' => 'Grace Hopper', 'role' => 'Contributor', 'status' => 'closed'],
+        ];
+        $tr = '';
+        foreach ($rows as $r) {
+            $tr .= '<tr><td>' . e($r['name']) . '</td><td>' . e($r['role']) . '</td>'
+                . '<td><span class="badge badge-' . e($r['status']) . '">' . e($r['status']) . '</span></td></tr>';
+        }
+        return '<table class="ds"><thead><tr><th>name</th><th>role</th><th>status</th></tr></thead><tbody>' . $tr . '</tbody></table>';
+    }),
+], 'data-display');
+
+$sb->register('Todo list', [
+    sb_variant(
+        'default',
+        fn($a) => '<div class="todo"><ul id="rows"><li>Write the launch post</li><li>Record the demo gif</li></ul><button class="btn btn-secondary" hx-get="/ds/row" hx-target="#rows" hx-swap="beforeend">+ add row</button></div>',
+        [],
+        'Click **+ add row**: the mock returns a new row htmx appends.',
+        [sb_mock('GET /ds/row', fn($a) => '<li>New task</li>')]
+    ),
+], 'interactive');
+
+$sb->register('Skeleton (phantom-ui)', [
+    sb_variant('loading', fn($a) => $phantom(['loading' => true])),
+    sb_variant('loaded', fn($a) => $phantom(['loading' => false])),
+    sb_variant('controls', $phantom, [
+        sb_control('loading', 'bool', true),
+        sb_control('animation', 'select', 'shimmer', ['shimmer', 'pulse', 'breathe', 'solid']),
+    ]),
+], 'web components', 'A third-party Web Component (`@aejkatappaja/phantom-ui`) from jsdelivr.');
+
+$path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+if ($path === '/static/ds.css') {
+    header('Content-Type: text/css; charset=utf-8');
+    readfile(__DIR__ . '/ds.css');
+    return true;
+}
+[$status, $ct, $body] = $sb->handle($_SERVER['REQUEST_METHOD'], $path, $_GET);
+http_response_code($status);
+header("Content-Type: $ct");
+echo $body;

--- a/examples/node/target.js
+++ b/examples/node/target.js
@@ -1,0 +1,117 @@
+// Swapbook example target in plain Node stdlib. No deps, no templating lib, no
+// adapter package: it implements the Swapbook protocol (see SPEC.md) by hand.
+// Renders a subset of the shared demo design system (same ds.css classes as the
+// Go/Django/Rails/Laravel demos) to prove any stdlib server works.
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+
+const btn = (a) =>
+  `<button class="btn btn-${a.variant || "primary"} btn-${a.size || "md"}"${a.disabled ? " disabled" : ""}>${a.label || "Save"}</button>`;
+const badge = (a) => `<span class="badge badge-${a.status || "open"}">${a.label || "open"}</span>`;
+const card = (a) => {
+  const reviews = parseInt(a.reviews || 0, 10) || 0;
+  const p = reviews ? `<p class="muted">${reviews} review${reviews === 1 ? "" : "s"}</p>` : "";
+  return `<div class="card"><div class="card-head"><strong>${a.title || "Add dark mode"}</strong><span class="badge badge-${a.status || "open"}">${a.status || "open"}</span></div>${p}</div>`;
+};
+const TODO =
+  '<div class="todo"><ul id="rows"><li>Write the launch post</li><li>Record the demo gif</li></ul><button class="btn btn-secondary" hx-get="/ds/row" hx-target="#rows" hx-swap="beforeend">+ add row</button></div>';
+
+const ctl = (name, type, def, options) => ({ name, type, default: def, ...(options ? { options } : {}) });
+
+// A subset of the shared DS: static variants, live controls, and an htmx mock.
+const STORIES = [
+  { id: "button", name: "Button", group: "actions", docs: "The button primitive, from a raw Node server.", variants: [
+    { name: "primary", render: () => btn({ label: "Save", variant: "primary" }) },
+    { name: "secondary", render: () => btn({ label: "Cancel", variant: "secondary" }) },
+    { name: "danger", render: () => btn({ label: "Delete", variant: "danger" }) },
+    { name: "controls", render: btn, controls: [
+      ctl("label", "text", "Save"),
+      ctl("variant", "select", "primary", ["primary", "secondary", "danger"]),
+      ctl("size", "select", "md", ["sm", "md", "lg"]),
+      ctl("disabled", "bool", false),
+    ] },
+  ] },
+  { id: "badge", name: "Badge", group: "data-display", variants: [
+    { name: "open", render: () => badge({ status: "open", label: "open" }) },
+    { name: "merged", render: () => badge({ status: "merged", label: "merged" }) },
+    { name: "closed", render: () => badge({ status: "closed", label: "closed" }) },
+  ] },
+  { id: "pr-card", name: "PR Card", group: "data-display", variants: [
+    { name: "open", render: () => card({}) },
+    { name: "with-reviews", render: () => card({ title: "Refactor router", status: "merged", reviews: 3 }) },
+    { name: "controls", render: card, controls: [
+      ctl("title", "text", "Add dark mode"),
+      ctl("status", "select", "open", ["open", "merged", "closed"]),
+      ctl("reviews", "number", 0),
+    ] },
+  ] },
+  { id: "todo-list", name: "Todo list", group: "interactive", variants: [
+    { name: "default", render: () => TODO,
+      docs: "Click **+ add row**: the mock returns a new `<li>` htmx appends.",
+      mocks: [{ verb: "GET", path: "/ds/row", render: () => "<li>New task</li>" }] },
+  ] },
+];
+
+const find = (sid, vname) =>
+  (STORIES.find((s) => s.id === sid) || { variants: [] }).variants.find((v) => v.name === vname);
+
+const coerce = (controls, qs) => {
+  const args = {};
+  for (const c of controls || []) {
+    if (!(c.name in qs)) { args[c.name] = c.default; continue; } // absent -> default
+    const raw = qs[c.name];
+    if (c.type === "number") { const n = parseFloat(raw); args[c.name] = Number.isNaN(n) ? c.default : n; }
+    else if (c.type === "bool") args[c.name] = ["true", "1", "on"].includes(raw);
+    else args[c.name] = raw;
+  }
+  return args;
+};
+
+const manifest = () => ({
+  htmxSrc: "", cssSrc: "/static/ds.css",
+  stories: STORIES.map((s) => ({
+    id: s.id, name: s.name, group: s.group, docs: s.docs || "",
+    variants: s.variants.map((v) => ({ name: v.name, controls: v.controls || [], docs: v.docs || "" })),
+  })),
+});
+
+const dsCss = () => {
+  for (const cand of [path.join(__dirname, "ds.css"), "examples/shared/ds.css"]) {
+    if (fs.existsSync(cand)) return fs.readFileSync(cand, "utf8");
+  }
+  return "";
+};
+
+const send = (res, body, ct, code = 200) => {
+  res.writeHead(code, { "Content-Type": ct });
+  res.end(body);
+};
+
+const port = parseInt(process.argv[2] || "9091", 10);
+http
+  .createServer((req, res) => {
+    const url = new URL(req.url, "http://x");
+    const p = url.pathname;
+    const parts = p.split("/"); // ["", "_swapbook", kind, id, variant, ...]
+    const qs = Object.fromEntries(url.searchParams);
+    if (p === "/static/ds.css") send(res, dsCss(), "text/css; charset=utf-8");
+    else if (p === "/_swapbook/manifest.json") send(res, JSON.stringify(manifest()), "application/json");
+    else if (p.startsWith("/_swapbook/preview/")) {
+      const v = find(parts[3], parts[4]);
+      send(res, v ? v.render(coerce(v.controls, qs)) : "", "text/html", v ? 200 : 404);
+    } else if (p.startsWith("/_swapbook/mocks/")) {
+      const v = find(parts[3], parts[4]);
+      const body = v ? (v.mocks || []).map((m, i) => ({ verb: m.verb, path: m.path, index: i })) : [];
+      send(res, JSON.stringify(body), "application/json");
+    } else if (p.startsWith("/_swapbook/mock/")) {
+      const v = find(parts[3], parts[4]);
+      const mocks = (v && v.mocks) || [];
+      const i = parseInt(parts[5], 10);
+      send(res, mocks[i] ? mocks[i].render({}) : "", "text/html", v ? 200 : 404);
+    } else {
+      res.writeHead(404);
+      res.end();
+    }
+  })
+  .listen(port);

--- a/examples/python/target.py
+++ b/examples/python/target.py
@@ -1,0 +1,157 @@
+# Swapbook example target in plain Python stdlib. No deps, no templating lib,
+# no adapter package: it implements the Swapbook protocol (see SPEC.md) by hand.
+# Renders a subset of the shared demo design system (same ds.css classes as the
+# Go/Django/Rails/Laravel demos) to prove any stdlib server works.
+import json
+import os
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlsplit
+
+
+def btn(a):
+    dis = " disabled" if a.get("disabled") else ""
+    return f'<button class="btn btn-{a.get("variant", "primary")} btn-{a.get("size", "md")}"{dis}>{a.get("label", "Save")}</button>'
+
+
+def badge(a):
+    return f'<span class="badge badge-{a.get("status", "open")}">{a.get("label", "open")}</span>'
+
+
+def card(a):
+    title, status = a.get("title", "Add dark mode"), a.get("status", "open")
+    reviews = int(a.get("reviews", 0) or 0)
+    p = f'<p class="muted">{reviews} review{"" if reviews == 1 else "s"}</p>' if reviews else ""
+    return f'<div class="card"><div class="card-head"><strong>{title}</strong><span class="badge badge-{status}">{status}</span></div>{p}</div>'
+
+
+TODO = '<div class="todo"><ul id="rows"><li>Write the launch post</li><li>Record the demo gif</li></ul><button class="btn btn-secondary" hx-get="/ds/row" hx-target="#rows" hx-swap="beforeend">+ add row</button></div>'
+
+
+def ctl(name, type="text", default=None, options=None):
+    c = {"name": name, "type": type, "default": default}
+    if options:
+        c["options"] = options
+    return c
+
+
+# A subset of the shared DS: static variants, live controls, and an htmx mock.
+STORIES = [
+    {"id": "button", "name": "Button", "group": "actions", "docs": "The button primitive, from a raw Python server.", "variants": [
+        {"name": "primary", "render": lambda a: btn({"label": "Save", "variant": "primary"})},
+        {"name": "secondary", "render": lambda a: btn({"label": "Cancel", "variant": "secondary"})},
+        {"name": "danger", "render": lambda a: btn({"label": "Delete", "variant": "danger"})},
+        {"name": "controls", "render": btn, "controls": [
+            ctl("label", "text", "Save"),
+            ctl("variant", "select", "primary", ["primary", "secondary", "danger"]),
+            ctl("size", "select", "md", ["sm", "md", "lg"]),
+            ctl("disabled", "bool", False),
+        ]},
+    ]},
+    {"id": "badge", "name": "Badge", "group": "data-display", "variants": [
+        {"name": "open", "render": lambda a: badge({"status": "open", "label": "open"})},
+        {"name": "merged", "render": lambda a: badge({"status": "merged", "label": "merged"})},
+        {"name": "closed", "render": lambda a: badge({"status": "closed", "label": "closed"})},
+    ]},
+    {"id": "pr-card", "name": "PR Card", "group": "data-display", "variants": [
+        {"name": "open", "render": lambda a: card({})},
+        {"name": "with-reviews", "render": lambda a: card({"title": "Refactor router", "status": "merged", "reviews": 3})},
+        {"name": "controls", "render": card, "controls": [
+            ctl("title", "text", "Add dark mode"),
+            ctl("status", "select", "open", ["open", "merged", "closed"]),
+            ctl("reviews", "number", 0),
+        ]},
+    ]},
+    {"id": "todo-list", "name": "Todo list", "group": "interactive", "variants": [
+        {"name": "default", "render": lambda a: TODO,
+         "docs": "Click **+ add row**: the mock returns a new `<li>` htmx appends.",
+         "mocks": [{"verb": "GET", "path": "/ds/row", "render": lambda a: "<li>New task</li>"}]},
+    ]},
+]
+
+
+def find(sid, vname):
+    for s in STORIES:
+        if s["id"] == sid:
+            for v in s["variants"]:
+                if v["name"] == vname:
+                    return v
+    return None
+
+
+def coerce(controls, qs):
+    args = {}
+    for c in controls:
+        name, t = c["name"], c["type"]
+        if name not in qs:  # absent -> default; present-but-empty is a real value
+            args[name] = c["default"]
+            continue
+        raw = qs[name][0]
+        if t == "number":
+            try:
+                args[name] = float(raw)
+            except ValueError:
+                args[name] = c["default"]
+        elif t == "bool":
+            args[name] = raw in ("true", "1", "on")
+        else:
+            args[name] = raw
+    return args
+
+
+def manifest():
+    return {"htmxSrc": "", "cssSrc": "/static/ds.css", "stories": [
+        {"id": s["id"], "name": s["name"], "group": s["group"], "docs": s.get("docs", ""),
+         "variants": [{"name": v["name"], "controls": v.get("controls", []), "docs": v.get("docs", "")} for v in s["variants"]]}
+        for s in STORIES
+    ]}
+
+
+def ds_css():
+    for cand in (os.path.join(os.path.dirname(__file__), "ds.css"), "examples/shared/ds.css"):
+        if os.path.exists(cand):
+            with open(cand, encoding="utf-8") as f:
+                return f.read()
+    return ""
+
+
+class H(BaseHTTPRequestHandler):
+    def _send(self, body, ctype, code=200):
+        self.send_response(code)
+        self.send_header("Content-Type", ctype)
+        self.end_headers()
+        self.wfile.write(body.encode())
+
+    def do_GET(self):
+        u = urlsplit(self.path)
+        p, qs = u.path, parse_qs(u.query)
+        parts = p.split("/")  # ["", "_swapbook", kind, id, variant, ...]
+        if p == "/static/ds.css":
+            self._send(ds_css(), "text/css; charset=utf-8")
+        elif p == "/_swapbook/manifest.json":
+            self._send(json.dumps(manifest()), "application/json")
+        elif p.startswith("/_swapbook/preview/"):
+            v = find(parts[3], parts[4])
+            self._send(v["render"](coerce(v.get("controls", []), qs)) if v else "", "text/html", 200 if v else 404)
+        elif p.startswith("/_swapbook/mocks/"):
+            v = find(parts[3], parts[4])
+            body = [{"verb": m["verb"], "path": m["path"], "index": i} for i, m in enumerate(v.get("mocks", []))] if v else []
+            self._send(json.dumps(body), "application/json")
+        elif p.startswith("/_swapbook/mock/"):
+            v = find(parts[3], parts[4])
+            mocks = v.get("mocks", []) if v else []
+            i = int(parts[5])
+            self._send(mocks[i]["render"]({}) if 0 <= i < len(mocks) else "", "text/html", 200 if v else 404)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    do_POST = do_GET
+
+    def log_message(self, *a):
+        pass
+
+
+if __name__ == "__main__":
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 9090
+    HTTPServer(("", port), H).serve_forever()

--- a/examples/rails/config.ru
+++ b/examples/rails/config.ru
@@ -1,0 +1,133 @@
+# Single-file Rails app demoing the Swapbook adapter: boot a minimal
+# Rails::Application, render the shared demo design system through ActionView
+# (inline ERB), mount the adapter at /_swapbook, serve via rackup. Same
+# component set as the Go, Django and Laravel demos.
+require "action_controller/railtie"
+require_relative "swapbook"
+
+# erb renders an inline ERB template through real ActionView.
+def erb(tpl, locals = {})
+  ActionController::Base.render(inline: tpl, locals: locals)
+end
+
+BTN = ->(a) { erb('<button class="btn btn-<%= variant %> btn-<%= size %>"<%= disabled ? " disabled" : "" %>><%= label %></button>',
+  label: a["label"] || "Save", variant: a["variant"] || "primary", size: a["size"] || "md", disabled: a["disabled"] || false) }
+BADGE = ->(a) { erb('<span class="badge badge-<%= status %>"><%= label %></span>', status: a["status"] || "open", label: a["label"] || "open") }
+ALERT = ->(a) { erb('<div class="alert alert-<%= kind %>"><%= msg %></div>', kind: a["kind"] || "info", msg: a["message"] || "Heads up.") }
+CARD = ->(a) { erb(<<~ERB.chomp, title: a["title"] || "Add dark mode", status: a["status"] || "open", reviews: (a["reviews"] || 0).to_i)
+  <div class="card"><div class="card-head"><strong><%= title %></strong><span class="badge badge-<%= status %>"><%= status %></span></div><% if reviews.positive? %><p class="muted"><%= reviews %> review<%= "s" unless reviews == 1 %></p><% end %></div>
+ERB
+}
+FIELD = ->(a) { erb(<<~ERB.chomp, label: a["label"] || "Email", value: a["value"] || "", error: a["error"] || "", disabled: a["disabled"] || false)
+  <div class="field<%= error.empty? ? "" : " error" %>"><label><%= label %></label><input value="<%= value %>" placeholder="<%= label %>"<%= disabled ? " disabled" : "" %>><% unless error.empty? %><span class="err"><%= error %></span><% end %></div>
+ERB
+}
+EMPTY = ->(a) { erb('<div class="empty"><div class="mark">📭</div><h4><%= title %></h4><div><%= hint %></div></div>',
+  title: a["title"] || "No workouts yet", hint: a["hint"] || "Create your first one to get started.") }
+TABLE = ->(_a) { erb(<<~ERB.chomp, rows: [["Ada Lovelace", "Owner", "open"], ["Alan Turing", "Maintainer", "merged"], ["Grace Hopper", "Contributor", "closed"]])
+  <table class="ds"><thead><tr><th>name</th><th>role</th><th>status</th></tr></thead><tbody><% rows.each do |name, role, status| %><tr><td><%= name %></td><td><%= role %></td><td><span class="badge badge-<%= status %>"><%= status %></span></td></tr><% end %></tbody></table>
+ERB
+}
+TODO = ->(_a) { '<div class="todo"><ul id="rows"><li>Write the launch post</li><li>Record the demo gif</li></ul><button class="btn btn-secondary" hx-get="/ds/row" hx-target="#rows" hx-swap="beforeend">+ add row</button></div>' }
+PHANTOM = ->(a) { erb('<script src="https://cdn.jsdelivr.net/npm/@aejkatappaja/phantom-ui/dist/phantom-ui.cdn.js"></script><phantom-ui<%= loading ? " loading" : "" %> animation="<%= animation %>" style="display:block;max-width:420px"><div class="card"><div class="card-head"><strong>Ada Lovelace</strong></div><p class="muted">First programmer, probably.</p></div></phantom-ui>',
+  loading: a.fetch("loading", true), animation: a["animation"] || "shimmer") }
+
+REG = Swapbook::Registry.new(css_src: "/static/ds.css")
+
+REG.register("Button", group: "actions", docs: "The button primitive. `variant` and `size` are props, not classes you type.", variants: [
+  Swapbook.variant("primary", ->(_a) { BTN.call("label" => "Save", "variant" => "primary") }),
+  Swapbook.variant("secondary", ->(_a) { BTN.call("label" => "Cancel", "variant" => "secondary") }),
+  Swapbook.variant("danger", ->(_a) { BTN.call("label" => "Delete", "variant" => "danger") }),
+  Swapbook.variant("disabled", ->(_a) { BTN.call("label" => "Save", "disabled" => true) }),
+  Swapbook.variant("controls", BTN, controls: [
+    Swapbook.control("label", default: "Save"),
+    Swapbook.control("variant", type: "select", default: "primary", options: %w[primary secondary danger]),
+    Swapbook.control("size", type: "select", default: "md", options: %w[sm md lg]),
+    Swapbook.control("disabled", type: "bool", default: false),
+  ]),
+])
+
+REG.register("Badge", group: "data-display", variants: [
+  Swapbook.variant("open", ->(_a) { BADGE.call("status" => "open", "label" => "open") }),
+  Swapbook.variant("merged", ->(_a) { BADGE.call("status" => "merged", "label" => "merged") }),
+  Swapbook.variant("closed", ->(_a) { BADGE.call("status" => "closed", "label" => "closed") }),
+  Swapbook.variant("controls", BADGE, controls: [
+    Swapbook.control("status", type: "select", default: "open", options: %w[open merged closed]),
+    Swapbook.control("label", default: "open"),
+  ]),
+])
+
+REG.register("Alert", group: "feedback", variants: [
+  Swapbook.variant("info", ->(_a) { ALERT.call("kind" => "info", "message" => "A new version is available.") }),
+  Swapbook.variant("success", ->(_a) { ALERT.call("kind" => "success", "message" => "Saved successfully.") }),
+  Swapbook.variant("warning", ->(_a) { ALERT.call("kind" => "warning", "message" => "Your trial ends in 3 days.") }),
+  Swapbook.variant("error", ->(_a) { ALERT.call("kind" => "error", "message" => "Could not reach the server.") }),
+  Swapbook.variant("controls", ALERT, controls: [
+    Swapbook.control("kind", type: "select", default: "info", options: %w[info success warning error]),
+    Swapbook.control("message", default: "Heads up."),
+  ]),
+])
+
+REG.register("PR Card", group: "data-display", variants: [
+  Swapbook.variant("open", ->(_a) { CARD.call({}) }),
+  Swapbook.variant("with-reviews", ->(_a) { CARD.call("title" => "Refactor router", "status" => "merged", "reviews" => 3) }),
+  Swapbook.variant("controls", CARD, controls: [
+    Swapbook.control("title", default: "Add dark mode"),
+    Swapbook.control("status", type: "select", default: "open", options: %w[open merged closed]),
+    Swapbook.control("reviews", type: "number", default: 0),
+  ]),
+])
+
+REG.register("Field", group: "forms", variants: [
+  Swapbook.variant("default", ->(_a) { FIELD.call("label" => "Email") }),
+  Swapbook.variant("error", ->(_a) { FIELD.call("label" => "Email", "value" => "not-an-email", "error" => "Enter a valid email") }),
+  Swapbook.variant("disabled", ->(_a) { FIELD.call("label" => "Email", "value" => "you@example.com", "disabled" => true) }),
+  Swapbook.variant("controls", FIELD, controls: [
+    Swapbook.control("label", default: "Email"),
+    Swapbook.control("value", default: ""),
+    Swapbook.control("error", default: ""),
+    Swapbook.control("disabled", type: "bool", default: false),
+  ]),
+])
+
+REG.register("Empty state", group: "feedback", variants: [
+  Swapbook.variant("default", EMPTY, controls: [
+    Swapbook.control("title", default: "No workouts yet"),
+    Swapbook.control("hint", default: "Create your first one to get started."),
+  ]),
+])
+
+REG.register("Table", group: "data-display", variants: [Swapbook.variant("default", TABLE)])
+
+REG.register("Todo list", group: "interactive", variants: [
+  Swapbook.variant("default", TODO,
+    docs: "Click **+ add row**: the mock returns a new `<li>` htmx appends. Watch the swap-target flash in the inspector.",
+    mocks: [Swapbook.mock("GET /ds/row", ->(_a) { "<li>New task</li>" })]),
+])
+
+REG.register("Skeleton (phantom-ui)", group: "web components", docs: "A third-party **Web Component** (`@aejkatappaja/phantom-ui`) from jsdelivr. Toggle `loading` to swap skeleton and content.", variants: [
+  Swapbook.variant("loading", PHANTOM),
+  Swapbook.variant("loaded", ->(_a) { PHANTOM.call("loading" => false) }),
+  Swapbook.variant("controls", PHANTOM, controls: [
+    Swapbook.control("loading", type: "bool", default: true),
+    Swapbook.control("animation", type: "select", default: "shimmer", options: %w[shimmer pulse breathe solid]),
+  ]),
+])
+
+# Serve the shared demo stylesheet (sits next to config.ru in the image).
+DS_CSS = [File.join(__dir__, "ds.css"), "examples/shared/ds.css"].find { |p| File.exist?(p) }
+CSS_APP = ->(_env) { [200, { "content-type" => "text/css; charset=utf-8" }, [DS_CSS ? File.read(DS_CSS) : ""]] }
+
+class App < Rails::Application
+  config.eager_load = false
+  config.secret_key_base = "swapbook-demo"
+  config.hosts.clear # allow any host (container)
+  config.logger = Logger.new($stdout)
+  routes.append do
+    get "/static/ds.css", to: CSS_APP
+    mount REG => "/_swapbook"
+  end
+end
+App.initialize!
+
+run App

--- a/examples/ruby/target.rb
+++ b/examples/ruby/target.rb
@@ -1,0 +1,117 @@
+# Swapbook example target in plain Ruby stdlib (webrick). No gems, no templating,
+# no adapter package: it implements the Swapbook protocol (see SPEC.md) by hand.
+# Renders a subset of the shared demo design system (same ds.css classes as the
+# Go/Django/Rails/Laravel demos) to prove any stdlib server works.
+require "webrick"
+require "json"
+
+BTN = ->(a) { %(<button class="btn btn-#{a["variant"] || "primary"} btn-#{a["size"] || "md"}"#{a["disabled"] ? " disabled" : ""}>#{a["label"] || "Save"}</button>) }
+BADGE = ->(a) { %(<span class="badge badge-#{a["status"] || "open"}">#{a["label"] || "open"}</span>) }
+CARD = ->(a) {
+  reviews = (a["reviews"] || 0).to_i
+  p = reviews.positive? ? %(<p class="muted">#{reviews} review#{reviews == 1 ? "" : "s"}</p>) : ""
+  %(<div class="card"><div class="card-head"><strong>#{a["title"] || "Add dark mode"}</strong><span class="badge badge-#{a["status"] || "open"}">#{a["status"] || "open"}</span></div>#{p}</div>)
+}
+TODO = '<div class="todo"><ul id="rows"><li>Write the launch post</li><li>Record the demo gif</li></ul><button class="btn btn-secondary" hx-get="/ds/row" hx-target="#rows" hx-swap="beforeend">+ add row</button></div>'
+
+def ctl(name, type: "text", default: nil, options: nil)
+  { name: name, type: type, default: default, options: options }.compact
+end
+
+# A subset of the shared DS: static variants, live controls, and an htmx mock.
+STORIES = [
+  { id: "button", name: "Button", group: "actions", docs: "The button primitive, from a raw Ruby server.", variants: [
+    { name: "primary", render: ->(_a) { BTN.call("label" => "Save", "variant" => "primary") } },
+    { name: "secondary", render: ->(_a) { BTN.call("label" => "Cancel", "variant" => "secondary") } },
+    { name: "danger", render: ->(_a) { BTN.call("label" => "Delete", "variant" => "danger") } },
+    { name: "controls", render: BTN, controls: [
+      ctl("label", default: "Save"),
+      ctl("variant", type: "select", default: "primary", options: %w[primary secondary danger]),
+      ctl("size", type: "select", default: "md", options: %w[sm md lg]),
+      ctl("disabled", type: "bool", default: false),
+    ] },
+  ] },
+  { id: "badge", name: "Badge", group: "data-display", variants: [
+    { name: "open", render: ->(_a) { BADGE.call("status" => "open", "label" => "open") } },
+    { name: "merged", render: ->(_a) { BADGE.call("status" => "merged", "label" => "merged") } },
+    { name: "closed", render: ->(_a) { BADGE.call("status" => "closed", "label" => "closed") } },
+  ] },
+  { id: "pr-card", name: "PR Card", group: "data-display", variants: [
+    { name: "open", render: ->(_a) { CARD.call({}) } },
+    { name: "with-reviews", render: ->(_a) { CARD.call("title" => "Refactor router", "status" => "merged", "reviews" => 3) } },
+    { name: "controls", render: CARD, controls: [
+      ctl("title", default: "Add dark mode"),
+      ctl("status", type: "select", default: "open", options: %w[open merged closed]),
+      ctl("reviews", type: "number", default: 0),
+    ] },
+  ] },
+  { id: "todo-list", name: "Todo list", group: "interactive", variants: [
+    { name: "default", render: ->(_a) { TODO },
+      docs: "Click **+ add row**: the mock returns a new `<li>` htmx appends.",
+      mocks: [{ verb: "GET", path: "/ds/row", render: ->(_a) { "<li>New task</li>" } }] },
+  ] },
+].freeze
+
+def find(sid, vname)
+  s = STORIES.find { |st| st[:id] == sid }
+  s && s[:variants].find { |v| v[:name] == vname }
+end
+
+def coerce(controls, params)
+  (controls || []).each_with_object({}) do |c, args|
+    name = c[:name]
+    unless params.key?(name) # absent -> default; present-but-empty is real
+      args[name] = c[:default]
+      next
+    end
+    raw = params[name].to_s
+    args[name] =
+      case c[:type]
+      when "number" then (Float(raw) rescue c[:default])
+      when "bool" then %w[true 1 on].include?(raw)
+      else raw
+      end
+  end
+end
+
+def manifest
+  { htmxSrc: "", cssSrc: "/static/ds.css", stories: STORIES.map { |s|
+    { id: s[:id], name: s[:name], group: s[:group], docs: s[:docs] || "",
+      variants: s[:variants].map { |v| { name: v[:name], controls: v[:controls] || [], docs: v[:docs] || "" } } }
+  } }
+end
+
+def ds_css
+  cand = [File.join(__dir__, "ds.css"), "examples/shared/ds.css"].find { |p| File.exist?(p) }
+  cand ? File.read(cand) : ""
+end
+
+port = (ARGV[0] || 9092).to_i
+server = WEBrick::HTTPServer.new(Port: port, Logger: WEBrick::Log.new(File::NULL), AccessLog: [])
+server.mount_proc "/" do |req, res|
+  p = req.path
+  parts = p.split("/") # ["", "_swapbook", kind, id, variant, ...]
+  if p == "/static/ds.css"
+    res["Content-Type"] = "text/css; charset=utf-8"; res.body = ds_css
+  elsif p == "/_swapbook/manifest.json"
+    res["Content-Type"] = "application/json"; res.body = JSON.dump(manifest)
+  elsif p.start_with?("/_swapbook/preview/")
+    v = find(parts[3], parts[4])
+    res.status = v ? 200 : 404
+    res["Content-Type"] = "text/html"; res.body = v ? v[:render].call(coerce(v[:controls], req.query)) : ""
+  elsif p.start_with?("/_swapbook/mocks/")
+    v = find(parts[3], parts[4])
+    res["Content-Type"] = "application/json"
+    res.body = JSON.dump(v ? (v[:mocks] || []).each_with_index.map { |m, i| { verb: m[:verb], path: m[:path], index: i } } : [])
+  elsif p.start_with?("/_swapbook/mock/")
+    v = find(parts[3], parts[4])
+    mocks = (v && v[:mocks]) || []
+    i = parts[5].to_i
+    res.status = v ? 200 : 404
+    res["Content-Type"] = "text/html"; res.body = mocks[i] ? mocks[i][:render].call({}) : ""
+  else
+    res.status = 404
+  end
+end
+trap("INT") { server.shutdown }
+server.start

--- a/examples/shared/ds.css
+++ b/examples/shared/ds.css
@@ -1,0 +1,48 @@
+/* Shared demo design system for Swapbook examples. Light, self-contained
+   components (own surfaces) so they read on any preview canvas. Canonical copy;
+   the Django/Rails demos copy this same file. */
+* { box-sizing: border-box; }
+body { margin: 16px; font-family: system-ui, sans-serif; color: #1f2328; }
+
+.btn {
+  display: inline-flex; align-items: center; gap: 6px; font: inherit; cursor: pointer;
+  border: 1px solid transparent; border-radius: 6px; padding: 6px 14px; font-weight: 500;
+}
+.btn-md { font-size: 14px; } .btn-sm { font-size: 12px; padding: 4px 10px; } .btn-lg { font-size: 16px; padding: 9px 18px; }
+.btn-primary { background: #1f883d; color: #fff; }
+.btn-secondary { background: #f6f8fa; color: #24292f; border-color: #d0d7de; }
+.btn-danger { background: #cf222e; color: #fff; }
+.btn[disabled] { opacity: .5; cursor: not-allowed; }
+
+.badge { display: inline-block; font-size: 12px; font-weight: 500; padding: 3px 10px; border-radius: 999px; color: #fff; }
+.badge-open { background: #1a7f37; } .badge-merged { background: #8250df; } .badge-closed { background: #cf222e; }
+
+.alert { border-radius: 6px; padding: 12px 14px; font-size: 14px; border: 1px solid; }
+.alert-info { background: #ddf4ff; border-color: #54aeff; color: #0969da; }
+.alert-success { background: #dafbe1; border-color: #4ac26b; color: #1a7f37; }
+.alert-warning { background: #fff8c5; border-color: #d4a72c; color: #9a6700; }
+.alert-error { background: #ffebe9; border-color: #ff8182; color: #cf222e; }
+
+.card { background: #fff; border: 1px solid #d0d7de; border-radius: 8px; padding: 16px; max-width: 420px; }
+.card-head { display: flex; justify-content: space-between; align-items: center; }
+.card-head strong { font-size: 15px; }
+.card .muted { color: #57606a; font-size: 13px; margin: 10px 0 0; }
+
+.field { display: flex; flex-direction: column; gap: 6px; max-width: 360px; }
+.field label { font-size: 13px; font-weight: 500; }
+.field input { font: inherit; padding: 6px 10px; border: 1px solid #d0d7de; border-radius: 6px; }
+.field.error input { border-color: #cf222e; }
+.field .err { color: #cf222e; font-size: 12px; }
+.field input[disabled] { background: #f6f8fa; color: #8c959f; }
+
+.empty { text-align: center; color: #57606a; padding: 32px 16px; border: 1px dashed #d0d7de; border-radius: 8px; max-width: 420px; }
+.empty .mark { font-size: 28px; }
+.empty h4 { margin: 8px 0 4px; color: #1f2328; }
+
+table.ds { border-collapse: collapse; width: 100%; max-width: 520px; font-size: 14px; }
+table.ds th { text-align: left; color: #57606a; font-weight: 500; padding: 8px 12px; border-bottom: 1px solid #d0d7de; }
+table.ds td { padding: 8px 12px; border-bottom: 1px solid #eaeef2; }
+
+.todo { max-width: 420px; }
+.todo ul { list-style: none; margin: 0 0 10px; padding: 0; }
+.todo li { padding: 8px 12px; border: 1px solid #d0d7de; border-radius: 6px; margin-bottom: 6px; background: #fff; }

--- a/examples/smoke.sh
+++ b/examples/smoke.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Proves the Swapbook binary is framework/language-agnostic: it drives example
+# targets written in Python, Node and Ruby with zero per-language code in the
+# binary. Boots each target, points Swapbook at it, and asserts the protocol
+# flows end to end (manifest -> frame -> mock).
+set -u
+cd "$(dirname "$0")/.."
+
+BIN="$(mktemp -d)/swapbook"
+echo "building swapbook binary..."
+go build -o "$BIN" ./cmd/swapbook || exit 1
+
+# Each target now renders a subset of the shared demo design system, so the
+# protocol assertions are language-independent; the per-language `docs` string
+# in the manifest is the marker that proves this specific language is serving.
+# lang | run command | target port | UI port | language marker
+TARGETS=(
+  "python|python3 examples/python/target.py|9090|7101|raw Python server"
+  "node|node examples/node/target.js|9091|7102|raw Node server"
+  "ruby|ruby examples/ruby/target.rb|9092|7103|raw Ruby server"
+)
+
+fail=0
+for row in "${TARGETS[@]}"; do
+  IFS="|" read -r lang cmd tport uport langmark <<<"$row"
+  echo "── $lang ──────────────────────────────"
+
+  $cmd "$tport" >/dev/null 2>&1 &
+  tpid=$!
+  "$BIN" --target ":$tport" --port "$uport" >/dev/null 2>&1 &
+  spid=$!
+
+  ok=1
+  # wait for the target to be reachable THROUGH swapbook (manifest proxied)
+  for i in $(seq 1 40); do
+    curl -s "http://localhost:$uport/__sb/api/manifest" | grep -q '"button"' && break
+    sleep 0.3
+  done
+
+  manifest=$(curl -s "http://localhost:$uport/__sb/api/manifest")
+  frame=$(curl -s "http://localhost:$uport/__sb/frame/todo-list/default")
+  mock=$(curl -s "http://localhost:$uport/__sb/mock/todo-list/default/0")
+
+  echo "$manifest" | grep -q '"button"' && echo "  ✓ manifest" || { echo "  ✗ manifest"; ok=0; }
+  echo "$manifest" | grep -qF "$langmark" && echo "  ✓ language target ($langmark)" || { echo "  ✗ language target"; ok=0; }
+  echo "$frame" | grep -q '+ add row' && echo "  ✓ preview (DS component)" || { echo "  ✗ preview"; ok=0; }
+  echo "$frame" | grep -q 'window.__SB={"mode":"mock"' && echo "  ✓ mock config injected" || { echo "  ✗ mock config"; ok=0; }
+  echo "$frame" | grep -q '"GET /ds/row":"/__sb/mock/todo-list/default/0"' && echo "  ✓ mock route mapped" || { echo "  ✗ mock route"; ok=0; }
+  echo "$mock" | grep -q 'New task' && echo "  ✓ mock render" || { echo "  ✗ mock render"; ok=0; }
+  curl -s -o /dev/null -w "%{http_code}" "http://localhost:$uport/__sb/htmx.min.js" | grep -q 200 && echo "  ✓ embedded htmx served" || { echo "  ✗ embedded htmx"; ok=0; }
+
+  kill $spid $tpid 2>/dev/null
+  wait $spid $tpid 2>/dev/null
+  [ $ok -eq 1 ] && echo "  PASS" || { echo "  FAIL"; fail=1; }
+done
+
+echo "────────────────────────────────────────"
+[ $fail -eq 0 ] && echo "ALL TARGETS PASS" || echo "SOME TARGETS FAILED"
+exit $fail


### PR DESCRIPTION
## Summary
One demo design system rendered by every supported stack, so the gallery looks identical whatever the backend. Full nine-component set on Go, Django, Rails and Laravel; a four-component subset on the dependency-free Python, Node and Ruby targets (which implement the protocol by hand).

## Changes
- `examples/shared/ds.css`: the single canonical stylesheet every demo serves.
- Go reference demo (`html/template`), plus full demos for Django, Rails and Laravel.
- Python / Node / Ruby stdlib targets (subset), no adapter library.
- `examples/smoke.sh`: boots each stdlib target behind the binary and asserts manifest, frame and mock. New CI `smoke` job runs it.

## Verify
```
bash examples/smoke.sh   # ALL TARGETS PASS
```

Dockerized demos and the framework e2e follow in a separate PR.
