### PR TITLE
feat(examples): dockerized demos and framework e2e

### DIFF
--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -1,0 +1,36 @@
+name: e2e-docker
+
+# Building the Rails and Laravel demo images takes minutes, so this runs on main
+# and nightly (and on demand) rather than on every pull request.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "adapters/**"
+      - "examples/**"
+      - "internal/**"
+      - "cmd/**"
+      - ".github/workflows/e2e-docker.yml"
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  docker:
+    name: framework demos (django/rails/laravel)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: false
+      - name: build images + drive the protocol through the binary
+        run: bash examples/smoke-docker.sh

--- a/examples/django/Dockerfile
+++ b/examples/django/Dockerfile
@@ -1,0 +1,12 @@
+# Django demo target for Swapbook. Build from the repo root:
+#   docker build -f examples/django/Dockerfile -t swapbook-django .
+#   docker run --rm -p 8000:8000 swapbook-django
+# then: swapbook --target :8000
+FROM python:3.12-slim
+RUN pip install --no-cache-dir "django>=4.2,<6"
+WORKDIR /app
+COPY adapters/django/swapbook_adapter.py /app/
+COPY examples/django/app.py /app/
+COPY examples/shared/ds.css /app/ds.css
+EXPOSE 8000
+CMD ["python", "app.py"]

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,0 +1,22 @@
+# All five Swapbook demo targets at once:
+#   docker compose -f examples/docker-compose.yml up --build
+# then point the binary at any of them, e.g.:  swapbook --target :8000   (django)
+services:
+  go:
+    build: { context: .., dockerfile: examples/go/Dockerfile }
+    ports: ["8002:8000"]
+  python:
+    build: { context: .., dockerfile: examples/python/Dockerfile }
+    ports: ["9101:8000"]
+  node:
+    build: { context: .., dockerfile: examples/node/Dockerfile }
+    ports: ["9102:8000"]
+  ruby:
+    build: { context: .., dockerfile: examples/ruby/Dockerfile }
+    ports: ["9103:8000"]
+  django:
+    build: { context: .., dockerfile: examples/django/Dockerfile }
+    ports: ["8000:8000"]
+  rails:
+    build: { context: .., dockerfile: examples/rails/Dockerfile }
+    ports: ["8001:8000"]

--- a/examples/go/Dockerfile
+++ b/examples/go/Dockerfile
@@ -1,0 +1,10 @@
+# Build from the repo root: docker build -f examples/go/Dockerfile -t swapbook-go .
+FROM golang:1.26-alpine AS build
+WORKDIR /src
+COPY . .
+RUN CGO_ENABLED=0 go build -o /demo ./examples/go
+FROM alpine:3
+COPY --from=build /demo /demo
+COPY examples/shared/ds.css /ds.css
+EXPOSE 8000
+CMD ["/demo", "--css", "/ds.css"]

--- a/examples/laravel/Dockerfile
+++ b/examples/laravel/Dockerfile
@@ -1,0 +1,13 @@
+# Laravel/Blade demo target for Swapbook. Build from the repo root:
+#   docker build -f examples/laravel/Dockerfile -t swapbook-laravel .
+FROM php:8.3-cli
+RUN apt-get update && apt-get install -y --no-install-recommends unzip git && rm -rf /var/lib/apt/lists/*
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+WORKDIR /app
+COPY examples/laravel/composer.json /app/
+RUN composer update --no-interaction --no-dev
+COPY adapters/php/swapbook.php /app/
+COPY examples/laravel/server.php /app/
+COPY examples/shared/ds.css /app/ds.css
+EXPOSE 8000
+CMD ["php", "-S", "0.0.0.0:8000", "server.php"]

--- a/examples/node/Dockerfile
+++ b/examples/node/Dockerfile
@@ -1,0 +1,7 @@
+# Build from the repo root: docker build -f examples/node/Dockerfile -t swapbook-node .
+FROM node:22-slim
+WORKDIR /app
+COPY examples/node/target.js /app/
+COPY examples/shared/ds.css /app/ds.css
+EXPOSE 8000
+CMD ["node", "target.js", "8000"]

--- a/examples/python/Dockerfile
+++ b/examples/python/Dockerfile
@@ -1,0 +1,7 @@
+# Build from the repo root: docker build -f examples/python/Dockerfile -t swapbook-python .
+FROM python:3.12-slim
+WORKDIR /app
+COPY examples/python/target.py /app/
+COPY examples/shared/ds.css /app/ds.css
+EXPOSE 8000
+CMD ["python", "target.py", "8000"]

--- a/examples/rails/Dockerfile
+++ b/examples/rails/Dockerfile
@@ -1,0 +1,13 @@
+# Rails demo target for Swapbook. Build from the repo root:
+#   docker build -f examples/rails/Dockerfile -t swapbook-rails .
+#   docker run --rm -p 8001:8000 swapbook-rails
+# then: swapbook --target :8001
+FROM ruby:3.2-slim
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
+ && gem install railties actionpack actionview rackup puma --no-document \
+ && apt-get purge -y build-essential && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY adapters/rails/swapbook.rb examples/rails/config.ru /app/
+COPY examples/shared/ds.css /app/ds.css
+EXPOSE 8000
+CMD ["rackup", "-o", "0.0.0.0", "-p", "8000"]

--- a/examples/ruby/Dockerfile
+++ b/examples/ruby/Dockerfile
@@ -1,0 +1,8 @@
+# Build from the repo root: docker build -f examples/ruby/Dockerfile -t swapbook-ruby .
+FROM ruby:3.2-slim
+RUN gem install webrick --no-document
+WORKDIR /app
+COPY examples/ruby/target.rb /app/
+COPY examples/shared/ds.css /app/ds.css
+EXPOSE 8000
+CMD ["ruby", "target.rb", "8000"]

--- a/examples/smoke-docker.sh
+++ b/examples/smoke-docker.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Proves Swapbook drives real frameworks. Builds the Django and Rails demo
+# containers, points the Swapbook binary at each, and asserts the protocol
+# flows (manifest -> preview -> mock). Requires Docker.
+set -u
+cd "$(dirname "$0")/.."
+
+BIN="$(mktemp -d)/swapbook"
+echo "building swapbook binary..."
+go build -o "$BIN" ./cmd/swapbook || exit 1
+
+# lang | image | dockerfile | container port | UI port
+TARGETS=(
+  "django|swapbook-django|examples/django/Dockerfile|8000|7201"
+  "rails|swapbook-rails|examples/rails/Dockerfile|8000|7202"
+  "laravel|swapbook-laravel|examples/laravel/Dockerfile|8000|7203"
+)
+
+fail=0
+for row in "${TARGETS[@]}"; do
+  IFS="|" read -r lang image dockerfile cport uport <<<"$row"
+  echo "── $lang ──────────────────────────────"
+  docker build -q -f "$dockerfile" -t "$image" . >/dev/null || { echo "  ✗ build"; fail=1; continue; }
+  docker rm -f "sb-$lang" >/dev/null 2>&1
+  docker run -d --name "sb-$lang" -p "$cport" "$image" >/dev/null
+  hostport=$(docker port "sb-$lang" "$cport/tcp" | head -1 | sed 's/.*://')
+  "$BIN" --target ":$hostport" --port "$uport" >/dev/null 2>&1 &
+  spid=$!
+
+  ok=1
+  for i in $(seq 1 60); do curl -s "http://localhost:$uport/__sb/api/manifest" | grep -q '"pr-card"' && break; sleep 0.5; done
+  curl -s "http://localhost:$uport/__sb/api/manifest" | grep -q '"pr-card"' && echo "  ✓ manifest" || { echo "  ✗ manifest"; ok=0; }
+  curl -s "http://localhost:$uport/__sb/frame/pr-card/open" | grep -q "Add dark mode" && echo "  ✓ preview (component rendered)" || { echo "  ✗ preview"; ok=0; }
+  curl -s "http://localhost:$uport/__sb/frame/pr-card/controls?arg.status=merged&arg.reviews=4" | grep -q "4 reviews" && echo "  ✓ controls (props applied)" || { echo "  ✗ controls"; ok=0; }
+  curl -s "http://localhost:$uport/__sb/mock/todo-list/default/0" | grep -q "New task" && echo "  ✓ mock render" || { echo "  ✗ mock"; ok=0; }
+
+  kill $spid 2>/dev/null; wait $spid 2>/dev/null
+  docker rm -f "sb-$lang" >/dev/null 2>&1
+  [ $ok -eq 1 ] && echo "  PASS" || { echo "  FAIL"; fail=1; }
+done
+
+echo "────────────────────────────────────────"
+[ $fail -eq 0 ] && echo "ALL FRAMEWORK DEMOS PASS" || echo "SOME DEMOS FAILED"
+exit $fail


### PR DESCRIPTION
## Summary
Containerizes every demo target and adds an end-to-end check that drives the real framework demos through the binary. Kept on a separate, slower workflow (main, nightly, manual) so pull-request CI stays fast.

## Changes
- Dockerfiles for all seven targets plus `examples/docker-compose.yml` (brings them all up at once).
- `examples/smoke-docker.sh`: builds the Django, Rails and Laravel images and asserts the protocol through the binary.
- `e2e-docker` workflow: on push to main, a nightly cron, and `workflow_dispatch`.

## Verify
```
docker compose -f examples/docker-compose.yml up --build
bash examples/smoke-docker.sh   # ALL FRAMEWORK DEMOS PASS
```

The e2e workflow runs on merge to main (not on this PR) since the Rails and Laravel image builds take minutes.
