### PR TITLE
feat(dist): prebuilt binaries, install script, release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: release
+
+# Builds cross-platform binaries and publishes a GitHub Release when a version
+# tag is pushed:  git tag v0.1.0 && git push origin v0.1.0
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: false
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,42 @@
+# Release config for GoReleaser v2. Cut a release by pushing a tag:
+#   git tag v0.1.0 && git push origin v0.1.0
+# The release workflow (.github/workflows/release.yml) runs this.
+version: 2
+
+project_name: swapbook
+
+builds:
+  - id: swapbook
+    main: ./cmd/swapbook
+    binary: swapbook
+    env:
+      - CGO_ENABLED=0
+    goos: [linux, darwin, windows]
+    goarch: [amd64, arm64]
+    ldflags:
+      - -s -w -X main.version={{ .Version }}
+
+archives:
+  - id: default
+    formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - "^chore:"
+
+release:
+  github:
+    owner: Aejkatappaja
+    name: swapbook

--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ swapbook --target :8080
 <!-- TODO(launch): replace with a real demo.gif (inspector + controls + mock in action) -->
 <p align="center"><i>Demo gif coming soon. In the meantime, <a href="#try-the-demos">run the demos locally</a>.</i></p>
 
+## Install
+
+```
+# prebuilt binary (macOS / Linux)
+curl -fsSL https://raw.githubusercontent.com/Aejkatappaja/swapbook/main/install.sh | sh
+
+# or with Go
+go install github.com/Aejkatappaja/swapbook/cmd/swapbook@latest
+```
+
+Prebuilt binaries for macOS, Linux and Windows (amd64 / arm64) are attached to
+every [release](https://github.com/Aejkatappaja/swapbook/releases).
+
 ## Why
 
 Storybook is built around JS components; its HTML/Server modes are awkward and

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Install the latest Swapbook binary from GitHub Releases.
+#   curl -fsSL https://raw.githubusercontent.com/Aejkatappaja/swapbook/main/install.sh | sh
+# Override the install dir with DEST=~/.local/bin, or a version with VERSION=v0.1.0.
+set -eu
+
+REPO="Aejkatappaja/swapbook"
+BIN="swapbook"
+DEST="${DEST:-/usr/local/bin}"
+
+os=$(uname -s | tr '[:upper:]' '[:lower:]')
+arch=$(uname -m)
+case "$arch" in
+  x86_64 | amd64) arch=amd64 ;;
+  arm64 | aarch64) arch=arm64 ;;
+  *) echo "swapbook: unsupported architecture: $arch" >&2; exit 1 ;;
+esac
+case "$os" in
+  linux | darwin) ;;
+  *) echo "swapbook: unsupported OS: $os (use the Windows zip from Releases)" >&2; exit 1 ;;
+esac
+
+tag="${VERSION:-}"
+if [ -z "$tag" ]; then
+  tag=$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" \
+    | grep '"tag_name"' | head -1 | cut -d'"' -f4)
+fi
+[ -n "$tag" ] || { echo "swapbook: could not find a release" >&2; exit 1; }
+ver="${tag#v}"
+
+url="https://github.com/$REPO/releases/download/$tag/${BIN}_${ver}_${os}_${arch}.tar.gz"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+
+echo "swapbook: downloading $tag ($os/$arch)"
+curl -fsSL "$url" | tar -xz -C "$tmp"
+
+if [ -w "$DEST" ]; then
+  mv "$tmp/$BIN" "$DEST/$BIN"
+else
+  echo "swapbook: $DEST is not writable, using sudo"
+  sudo mv "$tmp/$BIN" "$DEST/$BIN"
+fi
+
+echo "swapbook: installed to $DEST/$BIN"
+"$DEST/$BIN" --version


### PR DESCRIPTION
## Summary
Distribution so non-Go users can install without the toolchain: prebuilt cross-platform binaries via GoReleaser, a curl one-liner, and a README install section.

## Changes
- `.goreleaser.yaml` + `release` workflow: pushing a `v*` tag builds linux / darwin / windows (amd64 + arm64), archives, checksums, and publishes a GitHub Release with the version stamped into the binary.
- `install.sh`: detects OS/arch and installs the latest release binary; override the dir with `DEST` or pin a `VERSION`.
- README: an Install section (curl one-liner, `go install`, releases).

## Verify
`sh -n install.sh` passes. The release pipeline runs on the first `v*` tag.

After merge, cut the first release to validate GoReleaser end to end:
```
git tag v0.1.0 && git push origin v0.1.0
```
