### PR TITLE
fix(cli): report module version for go install builds

### DIFF
--- a/cmd/swapbook/main.go
+++ b/cmd/swapbook/main.go
@@ -13,6 +13,7 @@ import (
 	"io/fs"
 	"log"
 	"net/http"
+	"runtime/debug"
 
 	"github.com/Aejkatappaja/swapbook/internal/server"
 )
@@ -20,8 +21,24 @@ import (
 //go:embed ui/*
 var uiFS embed.FS
 
-// version is stamped at build time via -ldflags "-X main.version=...".
+// version is stamped at build time via -ldflags "-X main.version=..." (release
+// builds). Left as "dev" otherwise.
 var version = "dev"
+
+// resolvedVersion prefers the ldflags value, then falls back to the module
+// version recorded by the Go toolchain, so "go install ...@v0.1.0" also reports
+// a real version instead of "dev".
+func resolvedVersion() string {
+	if version != "dev" {
+		return version
+	}
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		if v := bi.Main.Version; v != "" && v != "(devel)" {
+			return v
+		}
+	}
+	return version
+}
 
 func main() {
 	target := flag.String("target", ":8080", "target app address (host:port or URL)")
@@ -30,7 +47,7 @@ func main() {
 	flag.Parse()
 
 	if *showVersion {
-		fmt.Println("swapbook", version)
+		fmt.Println("swapbook", resolvedVersion())
 		return
 	}
 


### PR DESCRIPTION
## Summary
`go install` does not inject the GoReleaser ldflags, so `swapbook --version` printed `dev` for install-from-source users. Fall back to the module version recorded by the Go toolchain.

## Changes
- `resolvedVersion()` prefers the ldflags value (release binaries) and otherwise reads `runtime/debug.ReadBuildInfo().Main.Version`, so `go install .../cmd/swapbook@vX.Y.Z` reports the real version.

## Verify
```
go build ./cmd/swapbook && ./swapbook --version   # reports the git-derived version, not "dev"
```
Release binaries (install.sh) already report the tag via ldflags; this fixes the `go install` path for tags cut after this merge.
