### PR TITLE
feat(dist): npx launcher (run without installing)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,3 +26,25 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  npm:
+    name: publish npx launcher
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+      - name: publish to npm (skipped when NPM_TOKEN is not set)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "NPM_TOKEN not set; skipping npm publish."; exit 0
+          fi
+          version="${GITHUB_REF_NAME#v}"
+          cd packaging/npm
+          npm version "$version" --no-git-tag-version --allow-same-version
+          npm publish --access public

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ swapbook --target :8080
 # prebuilt binary (macOS / Linux)
 curl -fsSL https://raw.githubusercontent.com/Aejkatappaja/swapbook/main/install.sh | sh
 
+# or run without installing (Node)
+npx swapbook --target :8080
+
 # or with Go
 go install github.com/Aejkatappaja/swapbook/cmd/swapbook@latest
 ```

--- a/packaging/npm/README.md
+++ b/packaging/npm/README.md
@@ -1,0 +1,15 @@
+# swapbook
+
+Run [Swapbook](https://github.com/Aejkatappaja/swapbook), the component workbench for htmx and hypermedia, without installing anything:
+
+```
+npx swapbook --target :8080
+# then open http://localhost:7007/__sb/
+```
+
+This package is a thin launcher: on first run it downloads the prebuilt Swapbook
+binary for your platform from the matching GitHub Release, caches it, and runs
+it. There is no build step and no postinstall.
+
+See the [documentation](https://aejkatappaja.github.io/swapbook/) for the full
+guide.

--- a/packaging/npm/bin/swapbook.js
+++ b/packaging/npm/bin/swapbook.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// Thin launcher for `npx swapbook`. On first run it downloads the prebuilt
+// binary matching this package version + the host platform from GitHub
+// Releases, caches it, and execs it. No build, no postinstall.
+"use strict";
+
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { version } = require("../package.json");
+
+const REPO = "Aejkatappaja/swapbook";
+
+function target() {
+  const p = process.platform;
+  const a = process.arch;
+  const goos = p === "darwin" ? "darwin" : p === "linux" ? "linux" : p === "win32" ? "windows" : null;
+  const goarch = a === "x64" ? "amd64" : a === "arm64" ? "arm64" : null;
+  if (!goos || !goarch) {
+    console.error(`swapbook: unsupported platform ${p}/${a}`);
+    process.exit(1);
+  }
+  return {
+    goos,
+    goarch,
+    ext: goos === "windows" ? "zip" : "tar.gz",
+    bin: goos === "windows" ? "swapbook.exe" : "swapbook",
+  };
+}
+
+async function ensureBinary() {
+  const { goos, goarch, ext, bin } = target();
+  const cacheDir = path.join(os.homedir(), ".cache", "swapbook", version);
+  const binPath = path.join(cacheDir, bin);
+  if (fs.existsSync(binPath)) return binPath;
+
+  fs.mkdirSync(cacheDir, { recursive: true });
+  const asset = `swapbook_${version}_${goos}_${goarch}.${ext}`;
+  const url = `https://github.com/${REPO}/releases/download/v${version}/${asset}`;
+  process.stderr.write(`swapbook: downloading v${version} (${goos}/${goarch})\n`);
+
+  const res = await fetch(url); // Node 18+ follows the release redirect for us
+  if (!res.ok) {
+    console.error(`swapbook: download failed (${res.status}): ${url}`);
+    process.exit(1);
+  }
+  const archive = path.join(cacheDir, asset);
+  fs.writeFileSync(archive, Buffer.from(await res.arrayBuffer()));
+
+  // bsdtar (the system `tar` on macOS, Linux and Windows 10+) extracts both
+  // .tar.gz and .zip, so we avoid an npm dependency.
+  const r = spawnSync("tar", ["-xf", archive, "-C", cacheDir], { stdio: "inherit" });
+  if (r.status !== 0) {
+    console.error("swapbook: extraction failed (a `tar` on PATH is required)");
+    process.exit(1);
+  }
+  fs.unlinkSync(archive);
+  fs.chmodSync(binPath, 0o755);
+  return binPath;
+}
+
+ensureBinary()
+  .then((binPath) => {
+    const r = spawnSync(binPath, process.argv.slice(2), { stdio: "inherit" });
+    process.exit(r.status === null ? 1 : r.status);
+  })
+  .catch((err) => {
+    console.error("swapbook:", err && err.message ? err.message : err);
+    process.exit(1);
+  });

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "swapbook",
+  "version": "0.1.0",
+  "description": "Storybook for htmx and hypermedia. One binary, zero JS toolchain.",
+  "bin": {
+    "swapbook": "bin/swapbook.js"
+  },
+  "files": [
+    "bin/"
+  ],
+  "keywords": [
+    "htmx",
+    "hypermedia",
+    "storybook",
+    "component-workbench",
+    "design-system"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Aejkatappaja/swapbook.git"
+  },
+  "homepage": "https://aejkatappaja.github.io/swapbook/",
+  "license": "MIT",
+  "author": "Aejkatappaja",
+  "engines": {
+    "node": ">=18"
+  },
+  "os": [
+    "darwin",
+    "linux",
+    "win32"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
+  ]
+}


### PR DESCRIPTION
## Summary
`npx swapbook` support: run Swapbook without installing anything, aimed at the Node / htmx crowd.

## Changes
- `packaging/npm/`: an npm package (`swapbook`) whose `bin` downloads the prebuilt binary for the host platform from the matching GitHub Release, caches it under `~/.cache/swapbook/<version>`, and execs it. Zero npm dependencies (Node 18+ `fetch` and the system `tar`).
- `release` workflow auto-publishes the package on tag when an `NPM_TOKEN` secret is present (skips cleanly otherwise).
- README: `npx swapbook --target :8080` install option.

## Verify
Tested end to end against the live v0.1.0 release:
```
node packaging/npm/bin/swapbook.js --version
# swapbook: downloading v0.1.0 (darwin/arm64)
# swapbook 0.1.0
```

To make `npx swapbook` live: add an `NPM_TOKEN` repo secret (auto-publishes on the next tag), or publish once by hand:
```
cd packaging/npm && npm publish --access public
```
