### PR TITLE
fix: SSE streaming, CSP stripping, OOB swaps, and limitations doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,22 @@ Early. The protocol is proven across seven stacks with tests: Go/templ, Django,
 Rails and Laravel via adapters, plus dependency-free Python, Node and Ruby
 targets. Interfaces may still shift before a tagged release.
 
+## Limitations
+
+Swapbook is early and deliberately scoped. Known edges:
+
+- **htmx is the verified path.** The Turbo, Unpoly and Datastar inspector probes
+  are best-effort and not yet exercised against real apps.
+- **SSE and WebSocket** connections are proxied through, but the inspector does
+  not visualize their events (there is no discrete request to trace).
+- **Mocks are stateless.** A declared route returns a fixed response, so
+  multi-step flows whose output depends on earlier steps are out of scope.
+- **CSP is stripped from proxied responses** so previews can be framed and
+  instrumented. Swapbook is a local dev tool pointed at an app you own; it is not
+  a public proxy.
+- **Relative asset paths** inside a bare fragment may not resolve; prefer
+  app-absolute paths like `/static/...`.
+
 ## License
 
 MIT.

--- a/README.md
+++ b/README.md
@@ -274,15 +274,22 @@ Swapbook is early and deliberately scoped. Known edges:
 
 - **htmx is the verified path.** The Turbo, Unpoly and Datastar inspector probes
   are best-effort and not yet exercised against real apps.
+- **Auto-triggering components.** A preview with `hx-trigger="load"` or polling
+  (`every 2s`) fires real GET requests to your app in mock and safe mode; only
+  mutations are blocked. Mock those routes, or run against a dev database.
 - **SSE and WebSocket** connections are proxied through, but the inspector does
   not visualize their events (there is no discrete request to trace).
-- **Mocks are stateless.** A declared route returns a fixed response, so
-  multi-step flows whose output depends on earlier steps are out of scope.
-- **CSP is stripped from proxied responses** so previews can be framed and
-  instrumented. Swapbook is a local dev tool pointed at an app you own; it is not
-  a public proxy.
+- **Mocks return 200.** A declared route returns a fixed response, so multi-step
+  stateful flows are out of scope, and simulating error statuses (422, 500) to
+  exercise error swaps is planned but not yet supported.
+- **CSS.** Bare-fragment previews load your app's declared `cssSrc`. If your
+  styles are code-split or purged per route, point `cssSrc` at the full
+  stylesheet so previews match the app. Full-page components bring their own.
 - **Relative asset paths** inside a bare fragment may not resolve; prefer
   app-absolute paths like `/static/...`.
+
+Swapbook strips security headers and proxies your app, so it is a local
+development tool only. Never run it in production or expose it publicly.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -255,12 +255,13 @@ The [protocol spec](SPEC.md) documents the four endpoints an app implements.
 
 Shipped: protocol · mock/safe/live modes · htmx inspector (with Turbo, Unpoly and
 Datastar probes) · controls · response viewer · a11y lint · search · deep-links ·
-keyboard nav · copy-as-curl · swap-target highlight · canvas background toggle ·
-per-component autodocs · auto-reload on rebuild.
+keyboard nav · copy-as-curl · swap-target and out-of-band highlight · canvas
+background toggle · per-component autodocs · auto-reload · install via curl /
+npx / go install.
 
-Next: custom viewports, visual regression (screenshot + diff), play/interaction
-functions, distribution (Homebrew / `install.sh` / npx). Tracked in
-[issues](https://github.com/Aejkatappaja/swapbook/issues).
+Planned: error-status mocks, custom viewports, visual regression, play/interaction
+functions, Homebrew. Tracked in the
+[roadmap](https://github.com/Aejkatappaja/swapbook/labels/roadmap).
 
 ## Status
 

--- a/cmd/swapbook/ui/inspector.js
+++ b/cmd/swapbook/ui/inspector.js
@@ -189,6 +189,14 @@
           send(n, out);
         });
       });
+      // out-of-band swaps update elements other than the primary target; flash
+      // and log those too, else a multi-target response looks like nothing
+      // happened outside the main swap.
+      document.addEventListener("htmx:oobAfterSwap", function (/** @type {any} */ e) {
+        var t = (e.detail && e.detail.target) || e.target;
+        flash(t);
+        send("oobSwap", { target: eltDesc(t), lib: "htmx" });
+      });
     },
   };
 

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -124,6 +124,7 @@
     <a href="#cli">CLI</a>
     <a href="#adapters">Adapters</a>
     <a href="#protocol">Protocol</a>
+    <a href="#limitations">Limitations</a>
   </aside>
 
   <main>
@@ -260,6 +261,17 @@ $sb-&gt;<span class="fn">register</span>(<span class="st">"Button"</span>, [
       </tbody>
     </table>
     <p>Only the first two are required. The full schema is in the <a href="https://github.com/Aejkatappaja/swapbook/blob/main/SPEC.md">protocol specification</a>.</p>
+
+    <h2 id="limitations">Limitations <span class="k">// honest edges</span></h2>
+    <p>Swapbook is early and deliberately scoped. Worth knowing:</p>
+    <ul>
+      <li><b>htmx is the verified path.</b> The Turbo, Unpoly and Datastar probes are best-effort and not yet exercised against real apps.</li>
+      <li><b>Auto-triggering components.</b> A preview with <code>hx-trigger="load"</code> or polling (<code>every 2s</code>) fires real GET requests in mock and safe mode; only mutations are blocked. Mock those routes, or use a dev database.</li>
+      <li><b>SSE and WebSocket</b> connections are proxied through, but the inspector does not visualize their events.</li>
+      <li><b>Mocks return 200.</b> Responses are fixed, so stateful multi-step flows are out of scope, and error-status mocks (422, 500) are planned but not yet supported.</li>
+      <li><b>CSS.</b> Bare-fragment previews load your app's <code>cssSrc</code>. If your styles are code-split or purged per route, point <code>cssSrc</code> at the full stylesheet.</li>
+    </ul>
+    <div class="note">Swapbook strips security headers and proxies your app, so it is a local dev tool only. <b>Never run it in production or expose it publicly.</b></div>
   </main>
 </div>
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -45,31 +45,21 @@ func New(raw string, ui UI) (*Server, error) {
 		return nil, err
 	}
 	proxy := httputil.NewSingleHostReverseProxy(t)
-	// A workbench must be able to frame the target's pages. Strip framing
-	// guards from proxied responses so previews (and any in-frame navigation)
-	// are never blocked by the app's own X-Frame-Options / CSP frame-ancestors.
+	// Stream responses through instead of buffering, so Server-Sent Events
+	// (text/event-stream) reach the preview live rather than hanging.
+	proxy.FlushInterval = -1
+	// This is a local dev workbench that frames the target's pages and injects
+	// its inspector into them. Strip the app's framing guards and Content
+	// Security Policy from proxied responses: X-Frame-Options / CSP
+	// frame-ancestors would block framing, and a strict script-src would block
+	// the injected inspector. Only ever runs against a local target you own.
 	proxy.ModifyResponse = func(resp *http.Response) error {
 		resp.Header.Del("X-Frame-Options")
-		if csp := resp.Header.Get("Content-Security-Policy"); csp != "" {
-			resp.Header.Set("Content-Security-Policy", stripFrameAncestors(csp))
-		}
+		resp.Header.Del("Content-Security-Policy")
+		resp.Header.Del("Content-Security-Policy-Report-Only")
 		return nil
 	}
 	return &Server{target: t, proxy: proxy, ui: ui}, nil
-}
-
-// stripFrameAncestors removes the frame-ancestors directive from a CSP header
-// so the app's pages can be framed by the Swapbook preview.
-func stripFrameAncestors(csp string) string {
-	parts := strings.Split(csp, ";")
-	kept := parts[:0]
-	for _, d := range parts {
-		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(d)), "frame-ancestors") {
-			continue
-		}
-		kept = append(kept, d)
-	}
-	return strings.Join(kept, ";")
 }
 
 func normalize(raw string) (*url.URL, error) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -145,12 +145,8 @@ func TestStripsFramingHeaders(t *testing.T) {
 	if xfo := resp.Header.Get("X-Frame-Options"); xfo != "" {
 		t.Errorf("X-Frame-Options not stripped: %q", xfo)
 	}
-	csp := resp.Header.Get("Content-Security-Policy")
-	if strings.Contains(csp, "frame-ancestors") {
-		t.Errorf("frame-ancestors not stripped: %q", csp)
-	}
-	if !strings.Contains(csp, "default-src") {
-		t.Errorf("other CSP directives lost: %q", csp)
+	if csp := resp.Header.Get("Content-Security-Policy"); csp != "" {
+		t.Errorf("Content-Security-Policy not stripped: %q", csp)
 	}
 }
 


### PR DESCRIPTION
## Summary
Hardening prompted by a technical review: fix a few edges that would trip on apps more complex than the demo, and document the rest honestly.

## Changes
- **SSE**: `proxy.FlushInterval = -1` so Server-Sent Events stream to previews instead of buffering (previews no longer hang on `hx-sse`).
- **CSP**: strip the full `Content-Security-Policy` from proxied responses (not just `frame-ancestors`), so a strict `script-src` cannot block the injected inspector. Local dev proxy only.
- **hx-swap-oob**: the inspector now flashes and logs out-of-band swap targets, not only the primary one, so multi-target responses are visible.
- **README**: a Limitations section documenting the honest edges (htmx-verified only, SSE/WS not inspected, stateless mocks, CSP stripped, relative asset paths).

## Verify
```
go test ./...    # 12 pass
npx -p typescript tsc -p cmd/swapbook/ui/jsconfig.json   # 0 errors
```
