### PR TITLE
feat(adapters): registry-level shared mocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,8 +273,10 @@ targets. Interfaces may still shift before a tagged release.
 
 Swapbook is early and deliberately scoped. Known edges:
 
-- **htmx is the verified path.** The Turbo, Unpoly and Datastar inspector probes
-  are best-effort and not yet exercised against real apps.
+- **htmx is the verified path, any version.** Previews load your app's own htmx
+  via `htmxSrc`, so they run whatever version you ship (1.x or 2.x); the embedded
+  fallback used when `htmxSrc` is unset is htmx 2.0.4. The Turbo, Unpoly and
+  Datastar inspector probes are best-effort and not yet exercised against real apps.
 - **Auto-triggering components.** A preview with `hx-trigger="load"` or polling
   (`every 2s`) fires real GET requests to your app in mock and safe mode; only
   mutations are blocked. Mock those routes, or run against a dev database.

--- a/adapters/django/swapbook_adapter.py
+++ b/adapters/django/swapbook_adapter.py
@@ -63,11 +63,21 @@ class Registry:
     def __init__(self, htmx_src="", css_src="", js_src=""):
         self.htmx_src, self.css_src, self.js_src = htmx_src, css_src, js_src
         self._stories = []
+        self._global_mocks = []
 
     def register(self, name, variants, group="", docs=""):
         self._stories.append(
             {"id": slug(name), "name": name, "group": group, "docs": docs, "variants": variants}
         )
+
+    def mock(self, route, render):
+        """Declare a registry-level mock merged into every variant, for routes
+        shared across stories. A variant's own mock for the same route wins."""
+        self._global_mocks.append(mock(route, render))
+        return self
+
+    def _mocks_for(self, v):
+        return self._global_mocks + v["mocks"]
 
     def _find(self, sid, vname):
         for s in self._stories:
@@ -105,13 +115,17 @@ class Registry:
         v = self._find(sid, vname)
         if not v:
             return HttpResponseNotFound()
+        mks = self._mocks_for(v)
         return JsonResponse(
-            [{"verb": m["verb"], "path": m["path"], "index": i} for i, m in enumerate(v["mocks"])],
+            [{"verb": m["verb"], "path": m["path"], "index": i} for i, m in enumerate(mks)],
             safe=False,
         )
 
     def _mock(self, request, sid, vname, index):
         v = self._find(sid, vname)
-        if not v or index < 0 or index >= len(v["mocks"]):
+        if not v:
             return HttpResponseNotFound()
-        return HttpResponse(v["mocks"][index]["render"]({}))
+        mks = self._mocks_for(v)
+        if index < 0 or index >= len(mks):
+            return HttpResponseNotFound()
+        return HttpResponse(mks[index]["render"]({}))

--- a/adapters/go/adapter_test.go
+++ b/adapters/go/adapter_test.go
@@ -53,6 +53,40 @@ func TestManifestAndPreview(t *testing.T) {
 	}
 }
 
+func TestGlobalMocks(t *testing.T) {
+	reg := New()
+	reg.Mock("GET /shared", HTML("GLOBAL"))
+	reg.Register("Card",
+		Var("a", HTML("<div>a</div>")).Mock("POST /save", HTML("SAVED")),
+		Var("b", HTML("<div>b</div>")),
+	)
+	srv := httptest.NewServer(reg.Handler())
+	defer srv.Close()
+
+	// variant "a": registry mock first, then the variant's own
+	resp, _ := http.Get(srv.URL + "/mocks/card/a")
+	var la []MockMeta
+	json.NewDecoder(resp.Body).Decode(&la)
+	if len(la) != 2 || la[0].Path != "/shared" || la[1].Path != "/save" {
+		t.Fatalf("a mocks = %+v", la)
+	}
+	// variant "b" with no own mocks still inherits the registry mock
+	resp, _ = http.Get(srv.URL + "/mocks/card/b")
+	var lb []MockMeta
+	json.NewDecoder(resp.Body).Decode(&lb)
+	if len(lb) != 1 || lb[0].Path != "/shared" {
+		t.Fatalf("b mocks = %+v", lb)
+	}
+	// render the inherited global mock (index 0) on variant b
+	if resp, _ = http.Get(srv.URL + "/mock/card/b/0"); readBody(t, resp) != "GLOBAL" {
+		t.Errorf("global mock render wrong")
+	}
+	// render variant a's own mock (index 1, after the global)
+	if resp, _ = http.Post(srv.URL+"/mock/card/a/1", "", nil); readBody(t, resp) != "SAVED" {
+		t.Errorf("variant mock render wrong")
+	}
+}
+
 func TestMocks(t *testing.T) {
 	reg := New()
 	reg.Register("Card",

--- a/adapters/go/handler.go
+++ b/adapters/go/handler.go
@@ -134,8 +134,9 @@ func (r *Registry) serveMocks(w http.ResponseWriter, req *http.Request) {
 		http.NotFound(w, req)
 		return
 	}
-	out := make([]MockMeta, len(v.Mocks))
-	for i, m := range v.Mocks {
+	mocks := r.mocksFor(v)
+	out := make([]MockMeta, len(mocks))
+	for i, m := range mocks {
 		out[i] = MockMeta{Verb: m.Verb, Path: m.Path, Index: i}
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -146,12 +147,17 @@ func (r *Registry) serveMocks(w http.ResponseWriter, req *http.Request) {
 func (r *Registry) serveMock(w http.ResponseWriter, req *http.Request) {
 	v := r.findVariant(req.PathValue("id"), req.PathValue("variant"))
 	idx, err := strconv.Atoi(req.PathValue("index"))
-	if v == nil || err != nil || idx < 0 || idx >= len(v.Mocks) {
+	if v == nil {
+		http.NotFound(w, req)
+		return
+	}
+	mocks := r.mocksFor(v)
+	if err != nil || idx < 0 || idx >= len(mocks) {
 		http.NotFound(w, req)
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if err := v.Mocks[idx].Component.Render(req.Context(), w); err != nil {
+	if err := mocks[idx].Component.Render(req.Context(), w); err != nil {
 		http.Error(w, "render: "+err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/adapters/go/registry.go
+++ b/adapters/go/registry.go
@@ -171,10 +171,33 @@ type Registry struct {
 	// "/static/app.js"). Swapbook injects it (deferred) into bare-fragment
 	// previews so client-side behavior (typeaheads, delegated handlers) works.
 	JSSrc string
+
+	// globalMocks are declared once on the registry and merged into every
+	// variant, so routes shared across stories need not be repeated per variant.
+	globalMocks []Mock
 }
 
 // New creates an empty Registry.
 func New() *Registry { return &Registry{} }
+
+// Mock declares a registry-level mock merged into every variant, for routes
+// shared across stories (like Storybook's meta-level handlers). A variant's own
+// Mock for the same route takes precedence. Chainable.
+func (r *Registry) Mock(route string, c Renderer) *Registry {
+	verb, path := splitRoute(route)
+	r.globalMocks = append(r.globalMocks, Mock{Verb: verb, Path: path, Component: c})
+	return r
+}
+
+// mocksFor returns a variant's effective mocks: registry-level mocks first, then
+// the variant's own. A variant mock for a duplicate route overrides the global
+// one, since Swapbook keeps the later "VERB path" entry when building its map.
+func (r *Registry) mocksFor(v *Variant) []Mock {
+	out := make([]Mock, 0, len(r.globalMocks)+len(v.Mocks))
+	out = append(out, r.globalMocks...)
+	out = append(out, v.Mocks...)
+	return out
+}
 
 // Register adds a story built from a name and its variants. The story ID is
 // the slugified name; Group is optional and set via RegisterIn.

--- a/adapters/php/swapbook.php
+++ b/adapters/php/swapbook.php
@@ -29,6 +29,7 @@ function sb_variant(string $name, callable $render, array $controls = [], string
 class Swapbook
 {
     private array $stories = [];
+    private array $globalMocks = [];
     public string $htmxSrc = '';
     public string $cssSrc = '';
     public string $jsSrc = '';
@@ -36,6 +37,19 @@ class Swapbook
     public function register(string $name, array $variants, string $group = '', string $docs = ''): void
     {
         $this->stories[] = ['id' => self::slug($name), 'name' => $name, 'group' => $group, 'docs' => $docs, 'variants' => $variants];
+    }
+
+    /** Declare a registry-level mock merged into every variant, for routes
+     * shared across stories. A variant's own mock for the same route wins. */
+    public function mock(string $route, callable $render): static
+    {
+        $this->globalMocks[] = sb_mock($route, $render);
+        return $this;
+    }
+
+    private function mocksFor(array $v): array
+    {
+        return array_merge($this->globalMocks, $v['mocks']);
     }
 
     public static function slug(string $s): string
@@ -92,15 +106,19 @@ class Swapbook
                 return $this->notFound();
             }
             $out = [];
-            foreach ($v['mocks'] as $i => $mk) {
+            foreach ($this->mocksFor($v) as $i => $mk) {
                 $out[] = ['verb' => $mk['verb'], 'path' => $mk['path'], 'index' => $i];
             }
             return $this->json($out);
         }
         if (preg_match('#^/_swapbook/mock/([^/]+)/([^/]+)/(\d+)$#', $path, $m)) {
             $v = $this->find($m[1], $m[2]);
-            return ($v && isset($v['mocks'][(int) $m[3]]))
-                ? $this->html(($v['mocks'][(int) $m[3]]['render'])([]))
+            if (!$v) {
+                return $this->notFound();
+            }
+            $mks = $this->mocksFor($v);
+            return isset($mks[(int) $m[3]])
+                ? $this->html(($mks[(int) $m[3]]['render'])([]))
                 : $this->notFound();
         }
         return $this->notFound();

--- a/adapters/php/swapbook_test.php
+++ b/adapters/php/swapbook_test.php
@@ -71,5 +71,21 @@ check($st === 404, 'unknown preview 404');
 [$st] = $sb->handle('GET', '/nope', []);
 check($st === 404, 'non-swapbook path 404');
 
+// registry-level mocks merged into every variant
+$sb2 = new Swapbook();
+$sb2->mock('GET /shared', fn($a) => '<div>SHARED</div>');
+$sb2->register('Card', [
+    sb_variant('a', fn($a) => '<div>a</div>', [], '', [sb_mock('POST /save', fn($a) => 'SAVED')]),
+    sb_variant('b', fn($a) => '<div>b</div>'),
+], 'x');
+[, , $body] = $sb2->handle('GET', '/_swapbook/mocks/card/a', []);
+$la = json_decode($body, true);
+check(count($la) === 2 && $la[0]['path'] === '/shared' && $la[1]['path'] === '/save', 'registry mock first, then variant own');
+[, , $body] = $sb2->handle('GET', '/_swapbook/mocks/card/b', []);
+$lb = json_decode($body, true);
+check(count($lb) === 1 && $lb[0]['path'] === '/shared', 'variant without own mocks inherits the global');
+[$st, , $body] = $sb2->handle('GET', '/_swapbook/mock/card/b/0', []);
+check($st === 200 && $body === '<div>SHARED</div>', 'render inherited global mock');
+
 echo $fails === 0 ? "\nPHP ADAPTER: ALL PASS\n" : "\nPHP ADAPTER: $fails FAILED\n";
 exit($fails === 0 ? 0 : 1);

--- a/adapters/rails/swapbook.rb
+++ b/adapters/rails/swapbook.rb
@@ -29,10 +29,18 @@ module Swapbook
     def initialize(htmx_src: "", css_src: "", js_src: "")
       @htmx_src, @css_src, @js_src = htmx_src, css_src, js_src
       @stories = []
+      @global_mocks = []
     end
 
     def register(name, variants:, group: "", docs: "")
       @stories << { id: Swapbook.slug(name), name: name, group: group, docs: docs, variants: variants }
+    end
+
+    # Declare a registry-level mock merged into every variant, for routes shared
+    # across stories. A variant's own mock for the same route wins. Chainable.
+    def mock(route, render)
+      @global_mocks << Swapbook.mock(route, render)
+      self
     end
 
     # Rack entry point (PATH_INFO is relative to the mount point).
@@ -47,10 +55,11 @@ module Swapbook
         v ? html(v[:render].call(coerce(v[:controls], params))) : not_found
       when %r{\A/mocks/([^/]+)/([^/]+)\z}
         v = find($1, $2)
-        v ? json(v[:mocks].each_with_index.map { |m, i| { verb: m[:verb], path: m[:path], index: i } }) : not_found
+        v ? json(mocks_for(v).each_with_index.map { |m, i| { verb: m[:verb], path: m[:path], index: i } }) : not_found
       when %r{\A/mock/([^/]+)/([^/]+)/(\d+)\z}
         v = find($1, $2)
-        (v && v[:mocks][$3.to_i]) ? html(v[:mocks][$3.to_i][:render].call({})) : not_found
+        mk = v && mocks_for(v)[$3.to_i]
+        mk ? html(mk[:render].call({})) : not_found
       else
         not_found
       end
@@ -73,6 +82,11 @@ module Swapbook
     def find(sid, vname)
       s = @stories.find { |st| st[:id] == sid }
       s && s[:variants].find { |v| v[:name] == vname }
+    end
+
+    # registry-level mocks first, then the variant's own (which override on dup)
+    def mocks_for(v)
+      @global_mocks + v[:mocks]
     end
 
     def coerce(controls, params)

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -212,6 +212,8 @@ $sb-&gt;<span class="fn">register</span>(<span class="st">"Button"</span>, [
         <span class="fn">Mock</span>(<span class="st">"GET /ds/row"</span>, <span class="fn">TodoRow</span>()).
         <span class="fn">Doc</span>(<span class="st">"Click + add row: the mock returns a new &lt;li&gt; htmx appends."</span>),
 )</code></pre>
+    <p>Routes shared across stories (an autocomplete endpoint, a token fetch) can be declared once on the registry instead of on every variant, like Storybook's meta-level handlers. They merge into every variant; a variant's own mock for the same route wins.</p>
+    <pre><code>reg.<span class="fn">Mock</span>(<span class="st">"GET /app/exercises/search"</span>, <span class="fn">ExerciseSuggestions</span>())</code></pre>
 
     <h2 id="modes">Modes <span class="k">// mock · safe · live</span></h2>
     <p>The toolbar has three modes, deciding what happens to htmx requests fired from inside a story:</p>
@@ -265,7 +267,7 @@ $sb-&gt;<span class="fn">register</span>(<span class="st">"Button"</span>, [
     <h2 id="limitations">Limitations <span class="k">// honest edges</span></h2>
     <p>Swapbook is early and deliberately scoped. Worth knowing:</p>
     <ul>
-      <li><b>htmx is the verified path.</b> The Turbo, Unpoly and Datastar probes are best-effort and not yet exercised against real apps.</li>
+      <li><b>htmx is the verified path, any version.</b> Previews load your app's own htmx via <code>htmxSrc</code>, so they run whatever version you ship (1.x or 2.x); the embedded fallback is htmx 2.0.4. The Turbo, Unpoly and Datastar probes are best-effort and not yet exercised against real apps.</li>
       <li><b>Auto-triggering components.</b> A preview with <code>hx-trigger="load"</code> or polling (<code>every 2s</code>) fires real GET requests in mock and safe mode; only mutations are blocked. Mock those routes, or use a dev database.</li>
       <li><b>SSE and WebSocket</b> connections are proxied through, but the inspector does not visualize their events.</li>
       <li><b>Mocks return 200.</b> Responses are fixed, so stateful multi-step flows are out of scope, and error-status mocks (422, 500) are planned but not yet supported.</li>

--- a/docs/guide/controls-mocks-modes.md
+++ b/docs/guide/controls-mocks-modes.md
@@ -54,6 +54,21 @@ variant("default", todo,
     mocks=[mock("GET /ds/row", lambda a: "<li>New task</li>")])
 ```
 
+### Registry-level mocks
+
+Routes shared across many stories (an autocomplete endpoint, a token fetch) can
+be declared once on the registry instead of repeated on every variant, like
+Storybook's meta-level handlers. They are merged into every variant; a variant's
+own mock for the same route takes precedence.
+
+```go
+reg.Mock("GET /app/exercises/search", ExerciseSuggestions())
+reg.Mock("POST /app/workouts", Saved())
+```
+
+The same method exists on every adapter: `reg.mock(...)` in Django and Rails,
+`$sb->mock(...)` in PHP.
+
 ## Interaction modes
 
 The toolbar has three modes, passed into every preview. They decide what happens


### PR DESCRIPTION
## Summary
Registry-level shared mocks: declare a mock once on the registry and it merges into every variant, like Storybook's meta-level handlers. Closes #20.

## Changes
- `reg.Mock(...)` (Go/Django/Rails) and `$sb->mock(...)` (PHP), merged into each variant: registry mocks first, then the variant's own, which override on a duplicate route.
- Wire protocol unchanged (the adapter expands the `/mocks` list), so no binary change.
- Go and PHP unit tests for the merge + inheritance.
- Docs: registry-level mocks in the guide and docs site; plus a note that previews run the app's own htmx (any 1.x/2.x) via `htmxSrc`, with 2.0.4 as the embedded fallback.

## Verify
```
go test ./...                        # incl TestGlobalMocks
php adapters/php/swapbook_test.php   # incl registry-mock checks
```
Validated live against go-gym: every Workout Form variant (and Entry Row) now inherits the shared add-row / typeahead / submit mocks, no per-variant repetition.

Closes #20.
