### PR TITLE
docs: note the plain-JS + checkJs choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ a hand-rolled `/preview` page can't give you.
 - **Live controls.** Edit a component's props from the toolbar and re-render.
 - **a11y lint, search, deep-links, keyboard-driven.**
 
+The gallery UI is plain JavaScript, type-checked with JSDoc and `checkJs` in CI,
+not TypeScript: the whole tool is zero-build, so a compile step would defeat the
+point. The binary itself is Go with no dependencies.
+
 ## Quickstart
 
 ### Go / templ

--- a/docs/index.html
+++ b/docs/index.html
@@ -447,6 +447,7 @@
       <div class="feat"><div class="fi">▤</div><h3>Live controls &amp; docs</h3><p>Edit a component's props from the toolbar and re-render. Autodocs and a11y lint come built in.</p></div>
       <div class="feat"><div class="fi">◇</div><h3>Any stack</h3><p>Go, Django, Rails, Laravel, or any server that answers four HTTP endpoints. No Node build step.</p></div>
     </div>
+    <p style="font-family:var(--sans);color:var(--fg-dim);font-size:13.5px;margin:18px 0 0;max-width:72ch">The gallery UI is plain JavaScript, type-checked with JSDoc and checkJs in CI, not TypeScript: the whole tool is zero-build, so a compile step would defeat the point. The binary is Go with no dependencies.</p>
   </section>
 
   <!-- QUICKSTART -->


### PR DESCRIPTION
Adds a short line to the Why section explaining the UI is plain JS type-checked with JSDoc + checkJs (not TypeScript), because the tool is zero-build. Pre-empts a common launch question.