### PR TITLE
docs(site): bump version pill to v0.2

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -371,7 +371,7 @@
       <a href="docs.html">docs</a>
       <a href="#protocol" class="hide">protocol</a>
       <a href="#compare" class="hide">compare</a>
-      <span class="pill">v0.1 · MIT</span>
+      <span class="pill">v0.2 · MIT</span>
       <a class="gh" href="https://github.com/Aejkatappaja/swapbook">GitHub ↗</a>
     </nav>
   </div>


### PR DESCRIPTION
The landing page header still showed v0.1. Bump the pill to v0.2 now that v0.2.0 is released. Deploys via the Pages workflow on merge.