### PR TITLE
chore: .gitattributes for accurate language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# GitHub Linguist: make the language bar reflect the actual application source.
+# These overrides only affect language stats and some diff rendering; they change
+# nothing about the build or what ships.
+
+# htmx is bundled as an embedded fallback (third party), not our code.
+cmd/swapbook/ui/htmx.min.js linguist-vendored
+
+# The landing page and docs site are documentation, not application source.
+docs/**       linguist-documentation
+
+# Examples exist to demonstrate the protocol in each language.
+examples/**   linguist-documentation
+
+# Test suites are not part of the shipped language surface.
+test/**       linguist-vendored


### PR DESCRIPTION
Add `.gitattributes` so GitHub Linguist reflects the actual application source in
the language bar. Only affects language stats and some diff rendering; nothing
about the build or what ships.

- `cmd/swapbook/ui/htmx.min.js` -> vendored (bundled third-party htmx fallback)
- `docs/**` -> documentation (landing page + docs site)
- `examples/**` -> documentation (per-language protocol demos)
- `test/**` -> vendored (test suites, not the shipped language surface)

Currently the bar counts the embedded htmx (~50KB) and the docs site as source,
which overstates JS/HTML.