### PR TITLE
feat(adapters): optional status code per mock for error-state previews

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -91,6 +91,10 @@ Lists the routes this variant mocks. Return `[]` or `404` if none.
 Returns the mock HTML fragment (`Content-Type: text/html`) for the given
 `index`. Must accept any HTTP method (a mocked `POST` is rendered the same way).
 
+A mock may return a non-2xx status (e.g. `422`, `500`) to preview a component
+reacting to a failure (`hx-target-error`, status-conditional swaps). Swapbook
+proxies the status through unchanged, so the client library sees the real code.
+
 ## How Swapbook uses these
 
 The binary reverse-proxies every non-`/__sb/` request straight to the target,

--- a/adapters/django/swapbook_adapter.py
+++ b/adapters/django/swapbook_adapter.py
@@ -27,10 +27,12 @@ def control(name, type="text", default=None, options=None):
     return c
 
 
-def mock(route, render):
-    """A canned response: route is "VERB /path", render is (args)->str."""
+def mock(route, render, status=200):
+    """A canned response: route is "VERB /path", render is (args)->str.
+
+    Pass a non-2xx status (422, 500, …) to preview a component's error state."""
     verb, _, p = route.partition(" ") if " " in route else ("GET", "", route)
-    return {"verb": verb.upper(), "path": p or route, "render": render}
+    return {"verb": verb.upper(), "path": p or route, "render": render, "status": status}
 
 
 def variant(name, render, controls=None, docs="", mocks=None):
@@ -70,10 +72,10 @@ class Registry:
             {"id": slug(name), "name": name, "group": group, "docs": docs, "variants": variants}
         )
 
-    def mock(self, route, render):
+    def mock(self, route, render, status=200):
         """Declare a registry-level mock merged into every variant, for routes
         shared across stories. A variant's own mock for the same route wins."""
-        self._global_mocks.append(mock(route, render))
+        self._global_mocks.append(mock(route, render, status))
         return self
 
     def _mocks_for(self, v):
@@ -128,4 +130,5 @@ class Registry:
         mks = self._mocks_for(v)
         if index < 0 or index >= len(mks):
             return HttpResponseNotFound()
-        return HttpResponse(mks[index]["render"]({}))
+        mk = mks[index]
+        return HttpResponse(mk["render"]({}), status=mk.get("status", 200))

--- a/adapters/go/adapter_test.go
+++ b/adapters/go/adapter_test.go
@@ -119,6 +119,33 @@ func TestMocks(t *testing.T) {
 	}
 }
 
+// TestMockStatus proves a mock can serve a non-200 status for error-state
+// previews, while a plain Mock still defaults to 200.
+func TestMockStatus(t *testing.T) {
+	reg := New()
+	reg.Register("Card",
+		Var("empty", HTML("<div>card</div>")).
+			Mock("GET /app/rows", HTML("<div>ROW</div>")).
+			MockStatus("POST /app/save", 422, HTML("<div>invalid</div>")),
+	)
+	srv := httptest.NewServer(reg.Handler())
+	defer srv.Close()
+
+	// mock with an explicit status serves it, with the body intact
+	resp, _ := http.Post(srv.URL+"/mock/card/empty/1", "", nil)
+	if resp.StatusCode != 422 {
+		t.Errorf("mock status = %d, want 422", resp.StatusCode)
+	}
+	if got := readBody(t, resp); got != "<div>invalid</div>" {
+		t.Errorf("mock body = %q", got)
+	}
+	// a plain Mock still defaults to 200
+	resp, _ = http.Get(srv.URL + "/mock/card/empty/0")
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("default mock status = %d, want 200", resp.StatusCode)
+	}
+}
+
 // TestRendererDecoupled proves the adapter takes any Renderer, not just templ:
 // a custom RenderFunc renders through the same pipeline.
 func TestRendererDecoupled(t *testing.T) {

--- a/adapters/go/handler.go
+++ b/adapters/go/handler.go
@@ -157,6 +157,9 @@ func (r *Registry) serveMock(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if st := mocks[idx].Status; st != 0 {
+		w.WriteHeader(st)
+	}
 	if err := mocks[idx].Component.Render(req.Context(), w); err != nil {
 		http.Error(w, "render: "+err.Error(), http.StatusInternalServerError)
 	}

--- a/adapters/go/registry.go
+++ b/adapters/go/registry.go
@@ -41,6 +41,9 @@ type Mock struct {
 	Verb      string
 	Path      string
 	Component Renderer
+	// Status is the HTTP status served for this mock. Zero means 200; set a
+	// non-2xx code (422, 500, …) to preview a component's error state.
+	Status int
 }
 
 // Control declares one editable arg for a variant, rendered as a knob in the
@@ -120,6 +123,15 @@ func (v Variant) Mock(route string, c Renderer) Variant {
 	return v
 }
 
+// MockStatus is Mock with an explicit HTTP status, so a variant can preview a
+// component reacting to a failure (422, 500, …) instead of the default 200.
+// Chainable.
+func (v Variant) MockStatus(route string, status int, c Renderer) Variant {
+	verb, path := splitRoute(route)
+	v.Mocks = append(v.Mocks, Mock{Verb: verb, Path: path, Component: c, Status: status})
+	return v
+}
+
 // Doc attaches documentation (light markdown) shown in Swapbook's docs tab.
 // Chainable.
 func (v Variant) Doc(md string) Variant {
@@ -186,6 +198,14 @@ func New() *Registry { return &Registry{} }
 func (r *Registry) Mock(route string, c Renderer) *Registry {
 	verb, path := splitRoute(route)
 	r.globalMocks = append(r.globalMocks, Mock{Verb: verb, Path: path, Component: c})
+	return r
+}
+
+// MockStatus is Mock with an explicit HTTP status (422, 500, …) for a
+// registry-level mock. Chainable.
+func (r *Registry) MockStatus(route string, status int, c Renderer) *Registry {
+	verb, path := splitRoute(route)
+	r.globalMocks = append(r.globalMocks, Mock{Verb: verb, Path: path, Component: c, Status: status})
 	return r
 }
 

--- a/adapters/php/swapbook.php
+++ b/adapters/php/swapbook.php
@@ -15,10 +15,11 @@ function sb_control(string $name, string $type = 'text', $default = null, ?array
     return $c;
 }
 
-function sb_mock(string $route, callable $render): array
+// Pass a non-2xx $status (422, 500, …) to preview a component's error state.
+function sb_mock(string $route, callable $render, int $status = 200): array
 {
     [$verb, $path] = str_contains($route, ' ') ? explode(' ', $route, 2) : ['GET', $route];
-    return ['verb' => strtoupper($verb), 'path' => $path, 'render' => $render];
+    return ['verb' => strtoupper($verb), 'path' => $path, 'render' => $render, 'status' => $status];
 }
 
 function sb_variant(string $name, callable $render, array $controls = [], string $docs = '', array $mocks = []): array
@@ -41,9 +42,9 @@ class Swapbook
 
     /** Declare a registry-level mock merged into every variant, for routes
      * shared across stories. A variant's own mock for the same route wins. */
-    public function mock(string $route, callable $render): static
+    public function mock(string $route, callable $render, int $status = 200): static
     {
-        $this->globalMocks[] = sb_mock($route, $render);
+        $this->globalMocks[] = sb_mock($route, $render, $status);
         return $this;
     }
 
@@ -117,8 +118,9 @@ class Swapbook
                 return $this->notFound();
             }
             $mks = $this->mocksFor($v);
-            return isset($mks[(int) $m[3]])
-                ? $this->html(($mks[(int) $m[3]]['render'])([]))
+            $mk = $mks[(int) $m[3]] ?? null;
+            return $mk
+                ? $this->html(($mk['render'])([]), $mk['status'] ?? 200)
                 : $this->notFound();
         }
         return $this->notFound();
@@ -136,6 +138,6 @@ class Swapbook
     }
 
     private function json(array $o): array { return [200, 'application/json', json_encode($o)]; }
-    private function html(string $s): array { return [200, 'text/html; charset=utf-8', $s]; }
+    private function html(string $s, int $status = 200): array { return [$status, 'text/html; charset=utf-8', $s]; }
     private function notFound(): array { return [404, 'text/plain', 'not found']; }
 }

--- a/adapters/php/swapbook_test.php
+++ b/adapters/php/swapbook_test.php
@@ -65,6 +65,16 @@ check($st === 200 && ($mk[0]['verb'] ?? '') === 'GET' && ($mk[0]['path'] ?? '') 
 [$st, , $body] = $sb->handle('POST', '/_swapbook/mock/todo/default/0', []);
 check($st === 200 && $body === '<li>New task</li>', 'mock render');
 
+// mock with an explicit status serves it for error-state previews
+$sb3 = new Swapbook();
+$sb3->register('Form', [
+    sb_variant('invalid', fn($a) => '<div>form</div>', [], '', [
+        sb_mock('POST /save', fn($a) => '<div>invalid</div>', 422),
+    ]),
+]);
+[$st, , $body] = $sb3->handle('POST', '/_swapbook/mock/form/invalid/0', []);
+check($st === 422 && $body === '<div>invalid</div>', 'mock render honors status');
+
 // unknown routes -> 404
 [$st] = $sb->handle('GET', '/_swapbook/preview/nope/nope', []);
 check($st === 404, 'unknown preview 404');

--- a/adapters/rails/swapbook.rb
+++ b/adapters/rails/swapbook.rb
@@ -16,9 +16,10 @@ module Swapbook
     { name: name, type: type, default: default, options: options }.compact
   end
 
-  def self.mock(route, render)
+  # Pass a non-2xx status (422, 500, …) to preview a component's error state.
+  def self.mock(route, render, status: 200)
     verb, path = route.include?(" ") ? route.split(" ", 2) : ["GET", route]
-    { verb: verb.upcase, path: path, render: render }
+    { verb: verb.upcase, path: path, render: render, status: status }
   end
 
   def self.variant(name, render, controls: [], docs: "", mocks: [])
@@ -38,8 +39,8 @@ module Swapbook
 
     # Declare a registry-level mock merged into every variant, for routes shared
     # across stories. A variant's own mock for the same route wins. Chainable.
-    def mock(route, render)
-      @global_mocks << Swapbook.mock(route, render)
+    def mock(route, render, status: 200)
+      @global_mocks << Swapbook.mock(route, render, status: status)
       self
     end
 
@@ -59,7 +60,7 @@ module Swapbook
       when %r{\A/mock/([^/]+)/([^/]+)/(\d+)\z}
         v = find($1, $2)
         mk = v && mocks_for(v)[$3.to_i]
-        mk ? html(mk[:render].call({})) : not_found
+        mk ? html(mk[:render].call({}), mk[:status] || 200) : not_found
       else
         not_found
       end
@@ -107,7 +108,7 @@ module Swapbook
     end
 
     def json(obj) = [200, { "content-type" => "application/json" }, [JSON.generate(obj)]]
-    def html(str) = [200, { "content-type" => "text/html; charset=utf-8" }, [str.to_s]]
+    def html(str, status = 200) = [status, { "content-type" => "text/html; charset=utf-8" }, [str.to_s]]
     def not_found = [404, { "content-type" => "text/plain" }, ["not found"]]
   end
 end

--- a/examples/go/main.go
+++ b/examples/go/main.go
@@ -32,7 +32,19 @@ var (
 	tableT = tmpl(`<table class="ds"><thead><tr><th>name</th><th>role</th><th>status</th></tr></thead><tbody>{{range .}}<tr><td>{{.Name}}</td><td>{{.Role}}</td><td><span class="badge badge-{{.Status}}">{{.Status}}</span></td></tr>{{end}}</tbody></table>`)
 	todoT  = tmpl(`<div class="todo"><ul id="rows"><li>Write the launch post</li><li>Record the demo gif</li></ul><button class="btn btn-secondary" hx-get="/ds/row" hx-target="#rows" hx-swap="beforeend">+ add row</button></div>`)
 	rowT   = tmpl(`<li>New task</li>`)
-	phanT  = tmpl(`<script src="https://cdn.jsdelivr.net/npm/@aejkatappaja/phantom-ui/dist/phantom-ui.cdn.js"></script><phantom-ui{{if .Loading}} loading{{end}} animation="{{.Animation}}" style="display:block;max-width:420px"><div class="card"><div class="card-head"><strong>Ada Lovelace</strong></div><p class="muted">First programmer, probably.</p></div></phantom-ui>`)
+	// The response-targets extension lets htmx swap on an error status; the
+	// mock for POST /ds/save returns 422, so hx-target-422 renders the error body.
+	saveFormT = tmpl(`<script src="https://cdn.jsdelivr.net/npm/htmx-ext-response-targets@2.0.3"></script>
+<div hx-ext="response-targets" class="field">
+  <form hx-post="/ds/save" hx-target="#save-out" hx-target-422="#save-out" hx-swap="innerHTML">
+    <label>Email</label>
+    <input name="email" value="not-an-email">
+    <button class="btn btn-primary">Save</button>
+  </form>
+  <div id="save-out"></div>
+</div>`)
+	saveErrT = tmpl(`<div class="alert alert-error">Enter a valid email</div>`)
+	phanT    = tmpl(`<script src="https://cdn.jsdelivr.net/npm/@aejkatappaja/phantom-ui/dist/phantom-ui.cdn.js"></script><phantom-ui{{if .Loading}} loading{{end}} animation="{{.Animation}}" style="display:block;max-width:420px"><div class="card"><div class="card-head"><strong>Ada Lovelace</strong></div><p class="muted">First programmer, probably.</p></div></phantom-ui>`)
 )
 
 type row struct{ Name, Role, Status string }
@@ -139,6 +151,12 @@ func registry() *adapter.Registry {
 		adapter.Var("default", render(todoT, nil)).
 			Mock("GET /ds/row", render(rowT, nil)).
 			Doc("Click **+ add row**: the mock returns a new `<li>` htmx appends. Watch the swap-target flash in the inspector."),
+	)
+
+	reg.RegisterIn("interactive", "Form validation",
+		adapter.Var("invalid", render(saveFormT, nil)).
+			MockStatus("POST /ds/save", 422, render(saveErrT, nil)).
+			Doc("Click **Save**: the mock replies `422`, so `hx-target-422` swaps in the error alert. The inspector logs the request with its failing status."),
 	)
 
 	reg.RegisterIn("web components", "Skeleton (phantom-ui)",

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -31,6 +31,11 @@ func fakeTarget() *httptest.Server {
 	mux.HandleFunc(adapter.MountPath+"/mock/card/empty/0", func(w http.ResponseWriter, _ *http.Request) {
 		io.WriteString(w, `<div>MOCKROW</div>`)
 	})
+	// a mock that fails, to prove the overlay propagates a non-200 status
+	mux.HandleFunc(adapter.MountPath+"/mock/card/empty/1", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(422)
+		io.WriteString(w, `<div>INVALID</div>`)
+	})
 	return httptest.NewServer(mux)
 }
 
@@ -127,6 +132,18 @@ func TestMockWiring(t *testing.T) {
 	// the overlay serves the mock render from the adapter
 	if got := body(t, ts.URL+Overlay+"/mock/card/empty/0"); got != "<div>MOCKROW</div>" {
 		t.Errorf("mock render = %q", got)
+	}
+	// a non-200 mock status is propagated so the client sees the real code
+	resp, err := http.Get(ts.URL + Overlay + "/mock/card/empty/1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 422 {
+		t.Errorf("mock status = %d, want 422", resp.StatusCode)
+	}
+	if b, _ := io.ReadAll(resp.Body); string(b) != "<div>INVALID</div>" {
+		t.Errorf("failed mock body = %q", b)
 	}
 }
 


### PR DESCRIPTION
## What

Mocks always returned `200`, so a component's failure state (`hx-target-error`, status-conditional swaps) couldn't be previewed. This adds an optional HTTP status to a mock declaration.

Closes #11.

## Changes

- **Protocol** (`SPEC.md`): the mock render endpoint may return a non-2xx status; Swapbook proxies it through unchanged.
- **Adapters**: status per mock in all four.
  - Go: `Mock.Status` field + chainable `MockStatus(route, status, c)` on Variant & Registry.
  - Django: `mock(route, render, status=200)` + `registry.mock(...)`.
  - Rails: `mock(route, render, status: 200)` + `registry.mock(...)`.
  - PHP: `sb_mock(route, render, int $status = 200)` + `->mock(...)`.
- **Binary**: no change needed, `proxyPass` already forwards the upstream status.
- **Demo** (`examples/go`): new `Form validation` story returning `422` with `hx-target-422`.

## Design notes

- The mocks-*list* wire format is untouched. Status rides the render response; the inspector logs it via the response probe. Putting it on the list too would be dead data.
- Existing `Mock(...)` / `sb_mock(...)` calls keep working (default 200).

## Tests

- Go adapter: `TestMockStatus` (422 served, plain mock still 200).
- Binary: `TestMockWiring` asserts a `422` mock propagates through the overlay.
- PHP: `mock render honors status`.
- Verified end to end in the browser: inspector logs `POST /ds/save 422`, `responseError` fires, error alert swaps into `#save-out`.