### PR TITLE
feat(ui): project-defined viewports + per-story viewport memory

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -40,6 +40,9 @@ Returns the gallery contents and asset hints.
 {
   "htmxSrc": "/static/htmx.min.js",  // app-relative htmx URL, or "" to use Swapbook's embedded htmx
   "cssSrc":  "/static/app.css",      // app-relative stylesheet injected into bare-fragment previews, or ""
+  "viewports": [                     // optional named preview widths, added to the built-in full/tablet/phone
+    { "name": "wide", "w": "1440px" }
+  ],
   "stories": [
     {
       "id": "workout-form",          // slug, used in URLs

--- a/adapters/go/adapter_test.go
+++ b/adapters/go/adapter_test.go
@@ -53,6 +53,36 @@ func TestManifestAndPreview(t *testing.T) {
 	}
 }
 
+// TestViewportsInManifest proves project-declared viewports reach the manifest,
+// and that omitting them keeps the field absent (omitempty).
+func TestViewportsInManifest(t *testing.T) {
+	reg := New()
+	reg.Viewports = []Viewport{{Name: "wide", Width: "1440px"}}
+	reg.Register("Card", Var("a", HTML("<div>a</div>")))
+	srv := httptest.NewServer(reg.Handler())
+	defer srv.Close()
+
+	resp, _ := http.Get(srv.URL + "/manifest.json")
+	var m manifest
+	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+		t.Fatal(err)
+	}
+	if len(m.Viewports) != 1 || m.Viewports[0].Name != "wide" || m.Viewports[0].Width != "1440px" {
+		t.Fatalf("viewports = %+v", m.Viewports)
+	}
+
+	// no viewports declared -> omitted from the JSON entirely
+	reg2 := New()
+	reg2.Register("Card", Var("a", HTML("<div>a</div>")))
+	srv2 := httptest.NewServer(reg2.Handler())
+	defer srv2.Close()
+	resp, _ = http.Get(srv2.URL + "/manifest.json")
+	body := readBody(t, resp)
+	if strings.Contains(body, "viewports") {
+		t.Errorf("empty viewports should be omitted: %s", body)
+	}
+}
+
 func TestGlobalMocks(t *testing.T) {
 	reg := New()
 	reg.Mock("GET /shared", HTML("GLOBAL"))

--- a/adapters/go/handler.go
+++ b/adapters/go/handler.go
@@ -12,10 +12,11 @@ const MountPath = "/_swapbook"
 
 // manifest is the wire format Swapbook reads to build its gallery.
 type manifest struct {
-	HTMXSrc string      `json:"htmxSrc"`
-	CSSSrc  string      `json:"cssSrc"`
-	JSSrc   string      `json:"jsSrc"`
-	Stories []storyMeta `json:"stories"`
+	HTMXSrc   string      `json:"htmxSrc"`
+	CSSSrc    string      `json:"cssSrc"`
+	JSSrc     string      `json:"jsSrc"`
+	Viewports []Viewport  `json:"viewports,omitempty"`
+	Stories   []storyMeta `json:"stories"`
 }
 
 type storyMeta struct {
@@ -69,7 +70,7 @@ func (r *Registry) findVariant(id, variant string) *Variant {
 }
 
 func (r *Registry) serveManifest(w http.ResponseWriter, _ *http.Request) {
-	m := manifest{HTMXSrc: r.HTMXSrc, CSSSrc: r.CSSSrc, JSSrc: r.JSSrc}
+	m := manifest{HTMXSrc: r.HTMXSrc, CSSSrc: r.CSSSrc, JSSrc: r.JSSrc, Viewports: r.Viewports}
 	for _, s := range r.stories {
 		vs := make([]variantMeta, len(s.Variants))
 		for i, v := range s.Variants {

--- a/adapters/go/registry.go
+++ b/adapters/go/registry.go
@@ -46,6 +46,14 @@ type Mock struct {
 	Status int
 }
 
+// Viewport is a named preview width offered in the Swapbook UI in addition to
+// the built-in full/tablet/phone (e.g. {"wide", "1440px"}). Width is any CSS
+// length the preview element accepts.
+type Viewport struct {
+	Name  string `json:"name"`
+	Width string `json:"w"`
+}
+
 // Control declares one editable arg for a variant, rendered as a knob in the
 // Swapbook UI. Type is "text", "number", "bool" or "select".
 type Control struct {
@@ -183,6 +191,9 @@ type Registry struct {
 	// "/static/app.js"). Swapbook injects it (deferred) into bare-fragment
 	// previews so client-side behavior (typeaheads, delegated handlers) works.
 	JSSrc string
+	// Viewports are named preview widths the UI offers on top of its built-in
+	// full/tablet/phone. Optional.
+	Viewports []Viewport
 
 	// globalMocks are declared once on the registry and merged into every
 	// variant, so routes shared across stories need not be repeated per variant.

--- a/cmd/swapbook/ui/app.js
+++ b/cmd/swapbook/ui/app.js
@@ -8,7 +8,8 @@
  * @typedef {{ name: string, controls?: Control[], docs?: string }} VariantObj
  * @typedef {string | VariantObj} Variant  variants may be a bare name (hand-rolled targets) or an object
  * @typedef {{ id: string, name: string, group?: string, docs?: string, variants: Variant[] }} Story
- * @typedef {{ htmxSrc?: string, cssSrc?: string, jsSrc?: string, stories?: Story[] }} Manifest
+ * @typedef {{ name: string, w: string }} Viewport  a project-declared preview width
+ * @typedef {{ htmxSrc?: string, cssSrc?: string, jsSrc?: string, stories?: Story[], viewports?: Viewport[] }} Manifest
  * @typedef {{ source: string, seq?: number, event: string, data?: any }} SBMessage  posted by the frame's inspector
  */
 
@@ -17,6 +18,11 @@ const WIDTHS = [
   { label: "tablet", w: "768px" },
   { label: "phone", w: "375px" },
 ];
+// Built-ins plus any viewports the project declares in its manifest. Rebuilt on
+// every manifest load (extends the built-ins, deduped by label; built-ins win).
+let allWidths = WIDTHS.slice();
+/** @param {unknown} label @returns {boolean} is this a known viewport label */
+const hasWidth = (label) => allWidths.some((w) => w.label === label);
 const MODES = ["mock", "safe", "live"];
 const MODE_TITLES = {
   mock: "mocked routes served locally, unmocked writes blocked",
@@ -30,6 +36,15 @@ let htmxSrc = "", cssSrc = "", jsSrc = "";
 let mode = "mock";
 let widthLabel = "full";
 let bg = localStorage.getItem("swapbook:bg") || "dark";
+// Per-story viewport memory: switching to a story restores the width last used
+// for it. An explicit URL "w" still wins, so shared links stay exact.
+const VW_KEY = "swapbook:viewports";
+/** @type {Record<string, string>} storyId -> viewport label */
+let vwMem = {};
+try {
+  const parsed = JSON.parse(localStorage.getItem(VW_KEY) || "{}");
+  if (parsed && typeof parsed === "object") vwMem = parsed;
+} catch {}
 /** @type {Story[]} */ let allStories = [];
 /** @type {{ story: Story, variant: Variant } | null} */ let current = null;
 /** @type {Record<string, any>} */ let args = {};
@@ -55,6 +70,15 @@ function applyManifest(text) {
   cssSrc = m.cssSrc || "";
   jsSrc = m.jsSrc || "";
   allStories = m.stories || [];
+  allWidths = WIDTHS.slice();
+  if (Array.isArray(m.viewports)) {
+    for (const v of m.viewports) {
+      if (v && v.name && v.w && !allWidths.some((x) => x.label === v.name)) {
+        allWidths.push({ label: String(v.name), w: String(v.w) });
+      }
+    }
+  }
+  renderWidths(); // the manifest may add viewports, so rebuild the width bar
 }
 
 // fetchManifest classifies the target: "ok" (adapter answered with a manifest),
@@ -140,7 +164,7 @@ function showAutodocs() {
   el("autodocs").hidden = false;
 }
 
-function selectVariant(story, v, stateArgs) {
+function selectVariant(story, v, stateArgs, width) {
   docsView = false;
   showPreview();
   current = { story, variant: v };
@@ -150,6 +174,10 @@ function selectVariant(story, v, stateArgs) {
   setActiveStory();
   renderControls(vControls(v));
   renderDocs(vDocs(v));
+  // Resolve the viewport once: an explicit width (from the URL) wins, else the
+  // one last used for this story, else full. Applied without persisting, since
+  // only a deliberate pick should write the story's remembered width.
+  setWidth(width || (hasWidth(vwMem[story.id]) ? vwMem[story.id] : "full"), false);
   loadFrame();
   writeState();
 }
@@ -325,12 +353,17 @@ function segmented(containerId, values, onpick, title) {
   }
   return (val) => qsa("button", bar).forEach((b) => b.classList.toggle("active", b.dataset.val === val));
 }
+// renderWidths rebuilds just the viewport bar; split out so a manifest load
+// (which may add project viewports) can refresh it without touching mode/bg.
+function renderWidths() {
+  setWidthActive = segmented("widths", allWidths.map((w) => w.label), setWidth);
+  setWidthActive(widthLabel);
+}
 function renderBars() {
   setModeActive = segmented("modes", MODES, setMode, (v) => MODE_TITLES[v] || "");
-  setWidthActive = segmented("widths", WIDTHS.map((w) => w.label), setWidth);
+  renderWidths();
   setBgActive = segmented("bgs", BGS, setBg);
   setModeActive(mode);
-  setWidthActive(widthLabel);
   setBgActive(bg);
   el("stage").style.background = bgCanvas(bg);
 }
@@ -340,11 +373,19 @@ function setMode(m) {
   loadFrame();
   writeState();
 }
-function setWidth(label) {
-  const p = WIDTHS.find((x) => x.label === label) || WIDTHS[0];
+// setWidth applies a viewport. persist=false is used for per-story recall (the
+// caller writes state itself); a deliberate pick (button/keyboard) persists the
+// story's remembered width and writes state here.
+function setWidth(label, persist = true) {
+  const p = allWidths.find((x) => x.label === label) || allWidths[0];
   widthLabel = p.label;
   el("preview").style.width = p.w;
   setWidthActive(p.label);
+  if (!persist) return;
+  if (current) {
+    vwMem[current.story.id] = p.label;
+    try { localStorage.setItem(VW_KEY, JSON.stringify(vwMem)); } catch {}
+  }
   writeState();
 }
 // bgCanvas maps a bg choice to the canvas (#stage) backdrop. dark is kept
@@ -391,19 +432,20 @@ function applyParams(str) {
   if (!story) return false;
   const v = story.variants.find((x) => vName(x) === p.get("variant")) || story.variants[0];
   if (MODES.includes(p.get("mode"))) mode = p.get("mode");
-  if (WIDTHS.some((w) => w.label === p.get("w"))) widthLabel = p.get("w");
+  const urlW = hasWidth(p.get("w")) ? p.get("w") : null;
   if (BGS.includes(p.get("bg"))) bg = p.get("bg");
   setModeActive(mode);
   setBgActive(bg);
   el("stage").style.background = bgCanvas(bg);
-  setWidth(widthLabel);
   if (p.get("docs") === "1") {
     selectDocs(story);
     return true;
   }
   const stateArgs = {};
   for (const [k, val] of p) if (k.startsWith("arg.")) stateArgs[k.slice(4)] = val;
-  selectVariant(story, v, stateArgs);
+  // Pass the URL width down so the whole precedence rule (URL > remembered >
+  // full) lives in selectVariant; a shared link never mutates local memory.
+  selectVariant(story, v, stateArgs, urlW);
   return true;
 }
 
@@ -627,7 +669,10 @@ document.addEventListener("keydown", (e) => {
   if (e.key === "/") { e.preventDefault(); return el("story-search").focus(); }
   if (e.key === "j") { e.preventDefault(); return moveStory(1); }
   if (e.key === "k") { e.preventDefault(); return moveStory(-1); }
-  if (e.key >= "1" && e.key <= "3") return setWidth(WIDTHS[+e.key - 1].label);
+  if (e.key >= "1" && e.key <= "9") {
+    const i = +e.key - 1;
+    return i < allWidths.length ? setWidth(allWidths[i].label) : undefined;
+  }
   if (e.key === "m") return setMode(MODES[(MODES.indexOf(mode) + 1) % MODES.length]);
 });
 

--- a/examples/go/main.go
+++ b/examples/go/main.go
@@ -62,6 +62,8 @@ func phantom(loading bool, anim string) adapter.Renderer {
 func registry() *adapter.Registry {
 	reg := adapter.New()
 	reg.CSSSrc = "/static/ds.css"
+	// Named viewports the UI offers on top of the built-in full/tablet/phone.
+	reg.Viewports = []adapter.Viewport{{Name: "wide", Width: "1440px"}, {Name: "mobile-lg", Width: "430px"}}
 
 	reg.RegisterIn("actions", "Button",
 		adapter.Var("primary", btn("Save", "primary", "md", false)),

--- a/test/ui/app.test.mjs
+++ b/test/ui/app.test.mjs
@@ -53,3 +53,49 @@ test("inspector ready line flags non-htmx probes as beta", async () => {
   assert.match(line, /datastar \(beta\)/);
   assert.doesNotMatch(line, /htmx \(beta\)/);
 });
+
+// A manifest declaring a custom viewport, plus two stories to switch between.
+const MANIFEST_VW = JSON.stringify({
+  htmxSrc: "",
+  cssSrc: "",
+  viewports: [{ name: "wide", w: "1440px" }],
+  stories: [
+    { id: "button", name: "Button", variants: [{ name: "primary" }] },
+    { id: "todo-list", name: "Todo list", variants: [{ name: "default" }] },
+  ],
+});
+const widthOf = (w) => w.document.getElementById("preview").style.width;
+
+test("project viewports extend the built-in width buttons", async () => {
+  const w = await boot(
+    async () => res(200, MANIFEST_VW),
+    (w) => txt(w, "stories").includes("Button"),
+  );
+  const labels = Array.from(
+    w.document.getElementById("widths").querySelectorAll("button"),
+  ).map((b) => b.textContent);
+  assert.deepEqual(labels, ["full", "tablet", "phone", "wide"]);
+});
+
+test("viewport choice is remembered per story", async () => {
+  const w = await boot(
+    async () => res(200, MANIFEST_VW),
+    (w) => txt(w, "stories").includes("Button"),
+  );
+  w.HTMLElement.prototype.scrollIntoView = () => {}; // not implemented in jsdom
+  const stories = w.currentStoryList();
+  const button = stories.find((s) => s.id === "button");
+  const todo = stories.find((s) => s.id === "todo-list");
+
+  w.selectVariant(button, button.variants[0]);
+  w.setWidth("wide");
+  assert.equal(widthOf(w), "1440px");
+
+  // a different story keeps its own default (full)…
+  w.selectVariant(todo, todo.variants[0]);
+  assert.equal(widthOf(w), "100%");
+
+  // …and returning to the first story restores its remembered viewport
+  w.selectVariant(button, button.variants[0]);
+  assert.equal(widthOf(w), "1440px");
+});


### PR DESCRIPTION
## What

Two things, per #13:

1. **Project-defined viewports** — the manifest gains an optional `viewports: [{name, w}]` field, so a project can offer named preview widths on top of the built-in full/tablet/phone. The Go adapter gets a `Viewport` type + `Registry.Viewports`; the field is language-agnostic, so any adapter can emit it.
2. **Per-story viewport memory** — the workbench remembers the viewport last used for each story (localStorage). An explicit URL `w` still wins, so shared links stay exact.

Closes #13.

## Notes

- Project viewports **extend** the built-ins (deduped by label, built-ins win).
- Precedence (URL > remembered > full) is resolved once in `selectVariant`, mirroring how `stateArgs` flows, so there is no set-then-override double write.
- A shared link never mutates local per-story memory (recall applies without persisting).
- Keyboard width shortcuts extended to `1`-`9`.
- Scope: the Go adapter got the typed API; Django/Rails/PHP can emit `viewports` in their manifest but weren't changed here (trivial follow-up).

## Post-review

Ran `/code-review` and `/simplify` on the diff: fixed the shared-link-clobbers-memory issue, guarded `vwMem` against non-object localStorage, collapsed the width-resolution into one site, and extracted a `hasWidth` helper for the duplicated membership check.

## Verified

gofmt/vet/build/test ✓, golangci-lint 0 ✓, jsdom **22** (2 new: viewports render, per-story recall) ✓, UI typecheck ✓, live manifest emits viewports ✓.