### PR TITLE
docs: document error-status mocks and custom viewports

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,13 +258,13 @@ The [protocol spec](SPEC.md) documents the four endpoints an app implements.
 ## Roadmap
 
 Shipped: protocol · mock/safe/live modes · htmx inspector (with Turbo, Unpoly and
-Datastar probes) · controls · response viewer · a11y lint · search · deep-links ·
-keyboard nav · copy-as-curl · swap-target and out-of-band highlight · canvas
-background toggle · per-component autodocs · auto-reload · install via curl /
-npx / go install.
+Datastar probes, verified end to end) · error-status mocks · controls · response
+viewer · a11y lint · search · deep-links · keyboard nav · copy-as-curl ·
+swap-target and out-of-band highlight · canvas background toggle · custom
+viewports · per-component autodocs · auto-reload · install via curl / npx /
+go install.
 
-Planned: error-status mocks, custom viewports, visual regression, play/interaction
-functions, Homebrew. Tracked in the
+Planned: visual regression, play/interaction functions, Homebrew. Tracked in the
 [roadmap](https://github.com/Aejkatappaja/swapbook/labels/roadmap).
 
 ## Status
@@ -280,15 +280,16 @@ Swapbook is early and deliberately scoped. Known edges:
 - **htmx is the verified path, any version.** Previews load your app's own htmx
   via `htmxSrc`, so they run whatever version you ship (1.x or 2.x); the embedded
   fallback used when `htmxSrc` is unset is htmx 2.0.4. The Turbo, Unpoly and
-  Datastar inspector probes are best-effort and not yet exercised against real apps.
+  Datastar inspector probes are best-effort; they are exercised against the real
+  libraries in a browser end-to-end test, but htmx remains the most complete path.
 - **Auto-triggering components.** A preview with `hx-trigger="load"` or polling
   (`every 2s`) fires real GET requests to your app in mock and safe mode; only
   mutations are blocked. Mock those routes, or run against a dev database.
 - **SSE and WebSocket** connections are proxied through, but the inspector does
   not visualize their events (there is no discrete request to trace).
-- **Mocks return 200.** A declared route returns a fixed response, so multi-step
-  stateful flows are out of scope, and simulating error statuses (422, 500) to
-  exercise error swaps is planned but not yet supported.
+- **Mocks are stateless.** A declared route returns a fixed response (a mock may
+  set a non-2xx status like 422/500 to exercise error swaps), so multi-step
+  stateful flows are out of scope.
 - **CSS.** Bare-fragment previews load your app's declared `cssSrc`. If your
   styles are code-split or purged per route, point `cssSrc` at the full
   stylesheet so previews match the app. Full-page components bring their own.

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -150,12 +150,14 @@ swapbook --version</code></pre>
 
 reg := adapter.<span class="fn">New</span>()
 reg.CSSSrc = <span class="st">"/static/app.css"</span> <span class="c">// injected into bare-fragment previews</span>
+reg.Viewports = []adapter.Viewport{{Name: <span class="st">"wide"</span>, Width: <span class="st">"1440px"</span>}} <span class="c">// optional named widths</span>
 
 reg.<span class="fn">RegisterIn</span>(<span class="st">"actions"</span>, <span class="st">"Button"</span>,
     adapter.<span class="fn">Var</span>(<span class="st">"primary"</span>,   <span class="fn">Button</span>(<span class="st">"Save"</span>, <span class="st">"primary"</span>)),
     adapter.<span class="fn">Var</span>(<span class="st">"secondary"</span>, <span class="fn">Button</span>(<span class="st">"Cancel"</span>, <span class="st">"secondary"</span>)),
 )
 reg.<span class="fn">DocStory</span>(<span class="st">"Button"</span>, <span class="st">"The button primitive."</span>)</code></pre>
+    <p class="muted">Viewports set via <code>reg.Viewports</code> appear in the toolbar's width bar next to the built-in full/tablet/phone, and the width you pick is remembered per story. Other stacks emit the same <code>viewports</code> list in their manifest.</p>
 
     <h3>Django</h3>
     <pre><code><span class="kw">from</span> swapbook_adapter <span class="kw">import</span> Registry, variant
@@ -214,6 +216,10 @@ $sb-&gt;<span class="fn">register</span>(<span class="st">"Button"</span>, [
 )</code></pre>
     <p>Routes shared across stories (an autocomplete endpoint, a token fetch) can be declared once on the registry instead of on every variant, like Storybook's meta-level handlers. They merge into every variant; a variant's own mock for the same route wins.</p>
     <pre><code>reg.<span class="fn">Mock</span>(<span class="st">"GET /app/exercises/search"</span>, <span class="fn">ExerciseSuggestions</span>())</code></pre>
+    <p>A mock serves <code>200</code> by default. Give it a non-2xx status to preview a component reacting to a failure (<code>hx-target-error</code>, status-conditional swaps); Swapbook proxies the status through unchanged.</p>
+    <pre><code>adapter.<span class="fn">Var</span>(<span class="st">"invalid"</span>, <span class="fn">SignupForm</span>()).
+    <span class="fn">MockStatus</span>(<span class="st">"POST /signup"</span>, 422, <span class="fn">ValidationErrors</span>())</code></pre>
+    <p class="muted">Other stacks take an optional status argument, e.g. <code>mock(route, render, status=422)</code> in Django.</p>
 
     <h2 id="modes">Modes <span class="k">// mock · safe · live</span></h2>
     <p>The toolbar has three modes, deciding what happens to htmx requests fired from inside a story:</p>
@@ -267,10 +273,10 @@ $sb-&gt;<span class="fn">register</span>(<span class="st">"Button"</span>, [
     <h2 id="limitations">Limitations <span class="k">// honest edges</span></h2>
     <p>Swapbook is early and deliberately scoped. Worth knowing:</p>
     <ul>
-      <li><b>htmx is the verified path, any version.</b> Previews load your app's own htmx via <code>htmxSrc</code>, so they run whatever version you ship (1.x or 2.x); the embedded fallback is htmx 2.0.4. The Turbo, Unpoly and Datastar probes are best-effort and not yet exercised against real apps.</li>
+      <li><b>htmx is the verified path, any version.</b> Previews load your app's own htmx via <code>htmxSrc</code>, so they run whatever version you ship (1.x or 2.x); the embedded fallback is htmx 2.0.4. The Turbo, Unpoly and Datastar probes are best-effort; they are exercised against the real libraries in a browser end-to-end test, but htmx remains the most complete path.</li>
       <li><b>Auto-triggering components.</b> A preview with <code>hx-trigger="load"</code> or polling (<code>every 2s</code>) fires real GET requests in mock and safe mode; only mutations are blocked. Mock those routes, or use a dev database.</li>
       <li><b>SSE and WebSocket</b> connections are proxied through, but the inspector does not visualize their events.</li>
-      <li><b>Mocks return 200.</b> Responses are fixed, so stateful multi-step flows are out of scope, and error-status mocks (422, 500) are planned but not yet supported.</li>
+      <li><b>Mocks are stateless.</b> A mock returns a fixed response (it may set a non-2xx status like 422/500 to exercise error swaps), so stateful multi-step flows are out of scope.</li>
       <li><b>CSS.</b> Bare-fragment previews load your app's <code>cssSrc</code>. If your styles are code-split or purged per route, point <code>cssSrc</code> at the full stylesheet.</li>
     </ul>
     <div class="note">Swapbook strips security headers and proxies your app, so it is a local dev tool only. <b>Never run it in production or expose it publicly.</b></div>

--- a/docs/guide/controls-mocks-modes.md
+++ b/docs/guide/controls-mocks-modes.md
@@ -69,6 +69,23 @@ reg.Mock("POST /app/workouts", Saved())
 The same method exists on every adapter: `reg.mock(...)` in Django and Rails,
 `$sb->mock(...)` in PHP.
 
+### Error-status mocks
+
+A mock serves `200` by default. Give it a non-2xx status to preview a component
+reacting to a failure (`hx-target-error`, status-conditional swaps). Swapbook
+proxies the status through unchanged, so the client library sees the real code.
+
+**Go** uses `MockStatus("VERB /path", status, renderer)`:
+
+```go
+adapter.Var("invalid", SignupForm()).
+    MockStatus("POST /signup", 422, ValidationErrors())
+```
+
+The other stacks take an optional status argument: `mock(route, render, status=422)`
+in Django, `mock(route, render, status: 422)` in Rails, and
+`sb_mock($route, $render, status: 422)` in PHP.
+
 ## Interaction modes
 
 The toolbar has three modes, passed into every preview. They decide what happens

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -46,6 +46,8 @@ func Workbench() http.Handler {
     reg.HTMXSrc = "/static/htmx.min.js" // your app's htmx build
     reg.CSSSrc = "/static/app.css"       // injected into bare-fragment previews
     reg.JSSrc = "/static/app.js"
+    // optional: named preview widths on top of the built-in full/tablet/phone
+    reg.Viewports = []adapter.Viewport{{Name: "wide", Width: "1440px"}}
 
     reg.RegisterIn("actions", "Button",
         adapter.Var("primary", Button("Save", "primary")),
@@ -60,6 +62,10 @@ mux.Handle(adapter.MountPath+"/", http.StripPrefix(adapter.MountPath, Workbench(
 Reload `http://localhost:7007/__sb/`: the Button story appears. From here, see
 [Writing stories](writing-stories.md) to add variants, controls and mocks, and
 [Controls, mocks and modes](controls-mocks-modes.md) to drive interactions.
+
+Any viewports set via `reg.Viewports` appear in the toolbar's width bar next to
+the built-ins; the width you pick is remembered per story. Other stacks emit the
+same `viewports` list in their manifest.
 
 ## How it works
 


### PR DESCRIPTION
## What

Docs catch-up for two shipped features (#11 error-status mocks, #13 custom viewports).

- **README** — moved error-status mocks + custom viewports from *Planned* to *Shipped*; updated the probes limitation (now exercised end to end via #16) and the mocks limitation (a mock may set a non-2xx status).
- **docs/guide/controls-mocks-modes.md** — new "Error-status mocks" section (`MockStatus` / per-stack `status` arg).
- **docs/guide/getting-started.md** — `reg.Viewports` in the registry config + a note that viewports show in the width bar and are remembered per story.
- **docs/docs.html** (hand-maintained site page) — mirrored the mock-status example, the Go registry `Viewports` line + note, and the two limitation updates.

Docs only, no code changes.