### PR TITLE
docs: add CONTRIBUTING and an authoring-an-adapter guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,90 @@
+# Contributing to Swapbook
+
+Thanks for helping out. Swapbook is small and deliberately scoped, so most
+changes are easy to reason about. This guide covers the layout, how to run the
+tests, and the conventions the repo follows.
+
+## The one idea to keep in mind
+
+Swapbook is a protocol, not a framework. The binary reverse-proxies your app and
+speaks the HTTP contract in [SPEC.md](SPEC.md); it knows nothing about your
+language. Adapters are optional ergonomic helpers that produce those responses.
+So when a change touches behavior on the wire, [SPEC.md](SPEC.md) is the source
+of truth and must be updated alongside it, and every adapter should stay
+consistent with the spec.
+
+## Project layout
+
+| Path | What lives there |
+| --- | --- |
+| `cmd/swapbook/` | the binary's entry point and the embedded gallery UI (`ui/`) |
+| `internal/server/` | the reverse proxy, frame injection, mock wiring |
+| `adapters/{go,django,rails,php}/` | the built-in adapters |
+| `examples/` | runnable demo targets per stack, including dependency-free `python`/`node`/`ruby` |
+| `docs/` | the guide (`guide/*.md`) and the hosted site (`docs.html`, `index.html`) |
+| `test/ui/` | jsdom tests for the browser UI and inspector |
+| `test/e2e/` | Playwright tests driving the real hypermedia libraries |
+| `SPEC.md` | the protocol contract |
+
+## Prerequisites
+
+- **Go** (stable) for the binary, the Go adapter, and building.
+- **Node** (20+) only if you touch the UI (`cmd/swapbook/ui/`) or the e2e tests.
+- **PHP / Ruby / Python** only if you touch those adapters or example targets.
+
+You do not need all of them. Install what the code you are changing needs.
+
+## Running the tests
+
+Mirror what CI runs (`.github/workflows/ci.yml`). Run the subset for what you
+touched:
+
+```sh
+# Go: format, vet, build, test with the race detector
+gofmt -l .            # must print nothing
+go vet ./...
+go build ./...
+go test -race ./...
+
+# Browser UI (jsdom) + type-check the // @ts-check UI
+cd test/ui && npm ci && npm test
+npx -y -p typescript tsc -p cmd/swapbook/ui/jsconfig.json
+
+# PHP adapter (no framework needed)
+php adapters/php/swapbook_test.php
+
+# Protocol smoke across the stdlib targets (python/node/ruby)
+bash examples/smoke.sh
+
+# End-to-end probes against real Turbo/Unpoly/Datastar (needs a browser)
+cd test/e2e && npm ci && npx playwright install chromium && npm test
+```
+
+The Go code is also linted with `golangci-lint run ./...`.
+
+## Conventions
+
+- **Commit messages** follow [Conventional Commits](https://www.conventionalcommits.org):
+  `type(scope): subject`, e.g. `feat(adapters): optional status code per mock`.
+  Common types here: `feat`, `fix`, `docs`, `test`, `chore`, `ci`.
+- **Keep it small.** Prefer the minimum change that solves the problem. The
+  adapters are intentionally tiny and dependency-free; new abstractions need a
+  clear reason.
+- **Match the surrounding style** rather than reformatting nearby code.
+- **Update docs and `SPEC.md`** when behavior or the protocol changes. The site
+  page `docs/docs.html` mirrors the guide, so update both.
+- Fill in the pull request template: what changed, how you verified it, and the
+  checklist.
+
+## Adding a new adapter
+
+New adapters (Flask, Phoenix, Express, Spring, and others) are welcome. You do
+not need to modify the binary: implement the protocol and open a PR. Start with
+[Authoring an adapter](docs/guide/authoring-adapters.md), which derives an
+adapter from `SPEC.md` step by step, and use `examples/python/target.py` as a
+dependency-free reference.
+
+## Reporting bugs and ideas
+
+Open an issue. For roadmap items, see the
+[`roadmap` label](https://github.com/Aejkatappaja/swapbook/labels/roadmap).

--- a/README.md
+++ b/README.md
@@ -242,8 +242,10 @@ Full guides live in [`docs/guide/`](docs/guide/):
 - [Controls, mocks and modes](docs/guide/controls-mocks-modes.md): live knobs, canned responses, the mock / safe / live gates.
 - [CLI reference](docs/guide/cli.md): flags and usage.
 - [Adapters](docs/guide/adapters.md): built-in adapters and writing your own.
+- [Authoring an adapter](docs/guide/authoring-adapters.md): derive a new adapter for any stack from the protocol.
 
 The [protocol spec](SPEC.md) documents the four endpoints an app implements.
+Want to help? See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Compared to
 

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -255,7 +255,7 @@ $sb-&gt;<span class="fn">register</span>(<span class="st">"Button"</span>, [
         <tr><td>Laravel / PHP</td><td>route <code>/_swapbook/*</code> to <code>$sb-&gt;handle(...)</code></td></tr>
       </tbody>
     </table>
-    <p>You do not need an adapter at all: any server answering the four endpoints works. A dependency-free reference is <code>examples/python/target.py</code> (about 140 lines of stdlib). Community adapters are welcome.</p>
+    <p>You do not need an adapter at all: any server answering the four endpoints works. A dependency-free reference is <code>examples/python/target.py</code> (about 140 lines of stdlib). Community adapters are welcome; the <a href="https://github.com/Aejkatappaja/swapbook/blob/main/docs/guide/authoring-adapters.md">authoring guide</a> derives one from the protocol step by step.</p>
 
     <h2 id="protocol">Protocol <span class="k">// four endpoints</span></h2>
     <p>The contract an app implements, under <code>/_swapbook</code>:</p>

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -12,6 +12,7 @@ isolation with an htmx-aware inspector, live controls and mocked interactions.
 - [Controls, mocks and modes](controls-mocks-modes.md): live knobs, canned responses, and the mock / safe / live gates.
 - [CLI reference](cli.md): flags and usage of the `swapbook` binary.
 - [Adapters](adapters.md): the built-in adapters and how to write your own.
+- [Authoring an adapter](authoring-adapters.md): derive a new adapter for any stack from the protocol.
 
 ## Reference
 

--- a/docs/guide/adapters.md
+++ b/docs/guide/adapters.md
@@ -35,5 +35,7 @@ and how full-page vs fragment previews are detected, is in the
 [protocol specification](../../SPEC.md).
 
 A minimal, dependency-free reference implementation is
-`examples/python/target.py` (about 140 lines of stdlib). Community adapters for
-other stacks are welcome; implement the protocol and open a PR.
+`examples/python/target.py` (about 140 lines of stdlib). For a step-by-step walk
+through the protocol, see [Authoring an adapter](authoring-adapters.md).
+Community adapters for other stacks are welcome; implement the protocol and open
+a PR.

--- a/docs/guide/authoring-adapters.md
+++ b/docs/guide/authoring-adapters.md
@@ -1,0 +1,161 @@
+# Authoring an adapter
+
+An adapter is the small piece in your app that answers the Swapbook protocol.
+There is nothing special about the built-in ones: they are just ergonomic
+wrappers around the four HTTP endpoints in the [protocol specification](../../SPEC.md).
+This guide derives an adapter from that spec so you can add one for any stack
+(Flask, Phoenix, Express, Spring, and so on).
+
+The reference to read alongside this is `examples/python/target.py`: a complete,
+dependency-free implementation in ~150 lines of stdlib. Everything below maps to
+a piece of it.
+
+## What you are building
+
+Swapbook mounts your responses under a fixed prefix on your app:
+
+```
+/_swapbook
+```
+
+Every non-`/__sb/` request is proxied straight to your app, so htmx requests
+fired from a preview reach it same-origin. Your adapter only has to answer these
+four routes:
+
+| Endpoint | Required | Purpose |
+| --- | --- | --- |
+| `GET /_swapbook/manifest.json` | yes | the gallery: stories, variants, control schemas, asset hints |
+| `GET /_swapbook/preview/{id}/{variant}` | yes | render one component as HTML |
+| `GET /_swapbook/mocks/{id}/{variant}` | for mock mode | list the routes a variant mocks |
+| `ANY /_swapbook/mock/{id}/{variant}/{index}` | for mock mode | render a mock response |
+
+Two conformance levels:
+
+- **Minimal**: `manifest.json` + `preview`. The gallery works and previews
+  render; interactions run in *safe*/*live* mode.
+- **Full**: add `mocks` + `mock` to enable *mock* mode (interactions with no
+  auth and no database).
+
+## 1. Model a story
+
+A **story** is one component with a slug `id`, a display `name`, an optional
+`group`, and one or more **variants**. A variant is a name plus a render
+function that returns an HTML string. That render function is the only thing
+coupling the adapter to your templating, so keep it a plain callable:
+
+```
+variant = { name, render(args) -> html, controls?, docs?, mocks? }
+story   = { id, name, group?, docs?, variants[] }
+```
+
+Keep a registry of stories in memory. Slugify the display name into the `id` the
+same way across endpoints (lowercase, non-alphanumeric to `-`) so URLs are
+stable.
+
+## 2. Serve the manifest
+
+`GET /_swapbook/manifest.json` returns the gallery contents and asset hints.
+Emit only metadata here, not rendered HTML:
+
+```jsonc
+{
+  "htmxSrc": "/static/htmx.min.js", // your app's htmx URL, or "" for the embedded fallback
+  "cssSrc":  "/static/app.css",     // stylesheet injected into bare-fragment previews, or ""
+  "jsSrc":   "/static/app.js",      // optional behavior script, or ""
+  "viewports": [                    // optional named preview widths, added to full/tablet/phone
+    { "name": "wide", "w": "1440px" }
+  ],
+  "stories": [
+    {
+      "id": "button",
+      "name": "Button",
+      "group": "actions",
+      "variants": [
+        { "name": "primary", "controls": [], "docs": "" }
+      ]
+    }
+  ]
+}
+```
+
+Content type is `application/json`.
+
+## 3. Render a preview
+
+`GET /_swapbook/preview/{id}/{variant}` returns the component's HTML with
+`Content-Type: text/html`. Two shapes are auto-detected by Swapbook:
+
+- **Full page** (response starts with `<!doctype` or `<html>`): served as-is,
+  Swapbook only injects its inspector. The page brings its own htmx and CSS.
+- **Bare fragment** (anything else): Swapbook wraps it in a minimal document and
+  injects htmx (`htmxSrc` or its embedded copy), the stylesheet (`cssSrc`) and
+  the inspector.
+
+If the variant has controls, coerce the query-string values into typed args
+before rendering. The rule: an absent control falls back to its default; a
+present-but-empty value is a real value (so a text field can be cleared).
+
+## 4. Coerce controls
+
+A control has a `name`, a `type` (`text`, `number`, `bool`, `select`), a
+`default`, and `options` for `select`. Coercion is the same in every adapter:
+
+```
+number -> parse, fall back to default on failure
+bool   -> true for "true" / "1" / "on"
+text/select -> the raw string
+```
+
+## 5. List and render mocks
+
+For mock mode, add the last two endpoints.
+
+`GET /_swapbook/mocks/{id}/{variant}` lists the routes a variant mocks. Return
+`[]` or `404` if none. The `index` is the position Swapbook will use to fetch
+the render:
+
+```jsonc
+[
+  { "verb": "GET",  "path": "/app/rows", "index": 0 },
+  { "verb": "POST", "path": "/app/save", "index": 1 }
+]
+```
+
+`ANY /_swapbook/mock/{id}/{variant}/{index}` renders the mock HTML for that
+index. It must accept any HTTP method (a mocked `POST` renders the same way). A
+mock serves `200` by default; you may return a non-2xx status (422, 500) so a
+component can be previewed reacting to a failure. Swapbook proxies the status
+through unchanged.
+
+## 6. (Optional) niceties the built-ins share
+
+- **Registry-level mocks**: routes shared across stories declared once and
+  merged into every variant, with a variant's own mock winning on a duplicate.
+- **Per-component docs**: a `docs` markdown string on a story or variant, shown
+  in the autodocs tab.
+
+These are conveniences, not protocol requirements.
+
+## Checklist
+
+- [ ] `manifest.json` lists every story and variant with correct slugs.
+- [ ] `preview` returns `text/html` and coerces controls (absent vs empty).
+- [ ] Unknown story/variant returns `404`.
+- [ ] `mocks` lists routes with stable `index` values; `mock` renders any method.
+- [ ] Mock status is honored if you support error-state previews.
+- [ ] The mount prefix is exactly `/_swapbook` and nothing else is intercepted.
+
+## Test it
+
+Point the binary at your app and open the gallery:
+
+```sh
+swapbook --target :8080
+# open http://localhost:7007/__sb/
+```
+
+Check the gallery lists your stories, previews render, controls re-render, and
+(for a full adapter) an interaction in mock mode is served from your mock
+endpoint. When it works, open a PR: see [Contributing](../../CONTRIBUTING.md).
+The dependency-free targets under `examples/{python,node,ruby}` are the smallest
+working references.


### PR DESCRIPTION
## What

Seeds community adapters (Flask, Phoenix, Express, Spring, ...), per #19.

- **CONTRIBUTING.md** (new) — project layout, per-language test commands (mirrors CI), commit/PR conventions, and the "protocol is the source of truth" rule. Points contributors at the authoring guide for new adapters.
- **docs/guide/authoring-adapters.md** (new) — derives an adapter from `SPEC.md` endpoint by endpoint (manifest → preview → controls → mocks), with conformance levels (minimal vs full), a checklist, and how to test it. Uses the dependency-free `examples/python/target.py` as the reference.
- Linked both from the README, the docs index, the adapters guide, and the hosted site page (`docs.html`).

Closes #19. Docs only, no code changes.

## Notes

Rebased onto `main` after #29 merged, so this includes the viewports/error-status doc updates plus the new guides (no overlap conflicts).