### PR TITLE
feat(server): inject auth headers into target requests for protected previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,8 +263,8 @@ Shipped: protocol · mock/safe/live modes · htmx inspector (with Turbo, Unpoly 
 Datastar probes, verified end to end) · error-status mocks · controls · response
 viewer · a11y lint · search · deep-links · keyboard nav · copy-as-curl ·
 swap-target and out-of-band highlight · canvas background toggle · custom
-viewports · per-component autodocs · auto-reload · install via curl / npx /
-go install.
+viewports · auth header injection for live-mode previews · per-component
+autodocs · auto-reload · install via curl / npx / go install.
 
 Planned: visual regression, play/interaction functions, Homebrew. Tracked in the
 [roadmap](https://github.com/Aejkatappaja/swapbook/labels/roadmap).
@@ -289,9 +289,13 @@ Swapbook is early and deliberately scoped. Known edges:
   mutations are blocked. Mock those routes, or run against a dev database.
 - **SSE and WebSocket** connections are proxied through, but the inspector does
   not visualize their events (there is no discrete request to trace).
-- **Mocks are stateless.** A declared route returns a fixed response (a mock may
-  set a non-2xx status like 422/500 to exercise error swaps), so multi-step
-  stateful flows are out of scope.
+- **Mocks are stateless.** You can set a mock's status (200 by default, or a
+  non-2xx like 422/500 to exercise error swaps), but it returns the same
+  response on every call, so multi-step stateful flows are out of scope.
+- **Auth is global.** `--header` injects the same credential into every request
+  forwarded to the target, so a session runs as one identity; there is no
+  per-story auth. Use a throwaway dev session (it lands in your shell history),
+  never a production token.
 - **CSS.** Bare-fragment previews load your app's declared `cssSrc`. If your
   styles are code-split or purged per route, point `cssSrc` at the full
   stylesheet so previews match the app. Full-page components bring their own.

--- a/cmd/swapbook/main.go
+++ b/cmd/swapbook/main.go
@@ -14,6 +14,7 @@ import (
 	"log"
 	"net/http"
 	"runtime/debug"
+	"strings"
 
 	"github.com/Aejkatappaja/swapbook/internal/server"
 )
@@ -40,10 +41,24 @@ func resolvedVersion() string {
 	return version
 }
 
+// headerFlags collects repeatable --header values ("Name: value").
+type headerFlags []string
+
+func (h *headerFlags) String() string { return strings.Join(*h, ", ") }
+func (h *headerFlags) Set(v string) error {
+	if !strings.Contains(v, ":") {
+		return fmt.Errorf("expected \"Name: value\", got %q", v)
+	}
+	*h = append(*h, v)
+	return nil
+}
+
 func main() {
 	target := flag.String("target", ":8080", "target app address (host:port or URL)")
 	port := flag.String("port", "7007", "port to serve the Swapbook UI on")
 	showVersion := flag.Bool("version", false, "print version and exit")
+	var headers headerFlags
+	flag.Var(&headers, "header", "header injected into every request to the target, e.g. --header 'Cookie: session=...' (repeatable) so components behind auth render in live mode")
 	flag.Parse()
 
 	if *showVersion {
@@ -55,7 +70,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("load ui: %v", err)
 	}
-	srv, err := server.New(*target, ui)
+	srv, err := server.New(*target, ui, headers...)
 	if err != nil {
 		log.Fatalf("bad target: %v", err)
 	}
@@ -63,6 +78,9 @@ func main() {
 	addr := ":" + *port
 	fmt.Printf("swapbook → target %s\n", *target)
 	fmt.Printf("open      http://localhost:%s%s/\n", *port, server.Overlay)
+	if len(headers) > 0 {
+		fmt.Printf("auth      injecting %d header(s) into target requests (live/safe mode)\n", len(headers))
+	}
 	log.Fatal(http.ListenAndServe(addr, srv.Handler()))
 }
 

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -239,9 +239,11 @@ $sb-&gt;<span class="fn">register</span>(<span class="st">"Button"</span>, [
       <tbody>
         <tr><td><code>--target</code></td><td><code>:8080</code></td><td>Address of the app to proxy. Accepts <code>:8080</code>, <code>localhost:8080</code> or a full URL.</td></tr>
         <tr><td><code>--port</code></td><td><code>7007</code></td><td>Port the Swapbook UI is served on.</td></tr>
+        <tr><td><code>--header</code></td><td></td><td>Header injected into every request to the target, as <code>Name: value</code>. Repeatable, so components behind auth render in live mode.</td></tr>
         <tr><td><code>--version</code></td><td></td><td>Print the version and exit.</td></tr>
       </tbody>
     </table>
+    <div class="note">Previews behind auth: in <code>safe</code>/<code>live</code> mode a preview hits your real app, so protected routes return 401. Pass the credential with <code>--header 'Cookie: session=...'</code> (repeatable) and Swapbook injects it into every proxied request. Use a throwaway dev session, never a production token; it appears in your shell history.</div>
     <p class="muted">The UI auto-reloads when your app rebuilds and reconnects if the target goes down. All UI assets are served <code>no-store</code>, so a rebuilt binary never serves a stale gallery.</p>
 
     <h2 id="adapters">Adapters <span class="k">// built-in &amp; custom</span></h2>
@@ -276,7 +278,8 @@ $sb-&gt;<span class="fn">register</span>(<span class="st">"Button"</span>, [
       <li><b>htmx is the verified path, any version.</b> Previews load your app's own htmx via <code>htmxSrc</code>, so they run whatever version you ship (1.x or 2.x); the embedded fallback is htmx 2.0.4. The Turbo, Unpoly and Datastar probes are best-effort; they are exercised against the real libraries in a browser end-to-end test, but htmx remains the most complete path.</li>
       <li><b>Auto-triggering components.</b> A preview with <code>hx-trigger="load"</code> or polling (<code>every 2s</code>) fires real GET requests in mock and safe mode; only mutations are blocked. Mock those routes, or use a dev database.</li>
       <li><b>SSE and WebSocket</b> connections are proxied through, but the inspector does not visualize their events.</li>
-      <li><b>Mocks are stateless.</b> A mock returns a fixed response (it may set a non-2xx status like 422/500 to exercise error swaps), so stateful multi-step flows are out of scope.</li>
+      <li><b>Mocks are stateless.</b> You can set a mock's status (200 by default, or a non-2xx like 422/500 to exercise error swaps), but it returns the same response on every call, so stateful multi-step flows are out of scope.</li>
+      <li><b>Auth is global.</b> <code>--header</code> injects the same credential into every request forwarded to the target, so a session runs as one identity (no per-story auth). Use a throwaway dev session, never a production token.</li>
       <li><b>CSS.</b> Bare-fragment previews load your app's <code>cssSrc</code>. If your styles are code-split or purged per route, point <code>cssSrc</code> at the full stylesheet.</li>
     </ul>
     <div class="note">Swapbook strips security headers and proxies your app, so it is a local dev tool only. <b>Never run it in production or expose it publicly.</b></div>

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -13,7 +13,25 @@ swapbook [flags]
 | --- | --- | --- |
 | `--target` | `:8080` | Address of the running app to proxy. Accepts `:8080`, `localhost:8080` or a full URL like `http://127.0.0.1:3000`. |
 | `--port` | `7007` | Port the Swapbook UI is served on. |
+| `--header` | | Header injected into every request forwarded to the target, as `Name: value`. Repeatable. |
 | `--version` | | Print the version and exit. |
+
+## Auth for protected routes
+
+In `safe` and `live` mode a preview's requests hit your real app, so components
+behind auth get a `401`/redirect. Pass the credential your app expects with
+`--header` and Swapbook injects it into every request it forwards to the target:
+
+```
+swapbook --target :8080 --header 'Cookie: session=<a-valid-dev-session>'
+# repeatable, and works for any header
+swapbook --target :8080 --header 'Authorization: Bearer <token>' --header 'X-Tenant: acme'
+```
+
+The gallery's own `/_swapbook` calls are not proxied, so they are unaffected;
+only requests to your app carry the header. Because the value is a real
+credential and appears in your shell history and process list, use a throwaway
+dev session and never a production token. This is a local dev tool only.
 
 ## Examples
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -39,12 +39,23 @@ type UI struct {
 }
 
 // New builds a Server proxying to raw (":8080", "localhost:8080" or a URL).
-func New(raw string, ui UI) (*Server, error) {
+// headers are "Name: value" strings injected into every request forwarded to
+// the target, so components behind auth render in safe/live mode (e.g. a
+// session cookie). Malformed entries (no colon) are ignored.
+func New(raw string, ui UI, headers ...string) (*Server, error) {
 	t, err := normalize(raw)
 	if err != nil {
 		return nil, err
 	}
 	proxy := httputil.NewSingleHostReverseProxy(t)
+	// Inject configured auth headers into every proxied (target-bound) request,
+	// so components behind auth render in safe/live mode. Done at the transport
+	// layer (not the deprecated Director) to leave the proxy's URL/host/path
+	// rewriting untouched. The gallery's own /_swapbook fetches use http.Get,
+	// not this proxy, so they are unaffected.
+	if inject := parseHeaders(headers); len(inject) > 0 {
+		proxy.Transport = &headerInjector{headers: inject, rt: http.DefaultTransport}
+	}
 	// Stream responses through instead of buffering, so Server-Sent Events
 	// (text/event-stream) reach the preview live rather than hanging.
 	proxy.FlushInterval = -1
@@ -60,6 +71,39 @@ func New(raw string, ui UI) (*Server, error) {
 		return nil
 	}
 	return &Server{target: t, proxy: proxy, ui: ui}, nil
+}
+
+type header struct{ name, value string }
+
+// headerInjector is a RoundTripper that sets configured headers on each request
+// before delegating. Safe to mutate the request here: ReverseProxy hands the
+// transport a per-request clone, not the caller's original.
+type headerInjector struct {
+	headers []header
+	rt      http.RoundTripper
+}
+
+func (h *headerInjector) RoundTrip(req *http.Request) (*http.Response, error) {
+	for _, x := range h.headers {
+		req.Header.Set(x.name, x.value)
+	}
+	return h.rt.RoundTrip(req)
+}
+
+// parseHeaders turns "Name: value" strings into header pairs, skipping any
+// entry without a colon. The value keeps its internal spacing; only the split
+// around the first colon is trimmed.
+func parseHeaders(raw []string) []header {
+	out := make([]header, 0, len(raw))
+	for _, h := range raw {
+		name, value, ok := strings.Cut(h, ":")
+		name = strings.TrimSpace(name)
+		if !ok || name == "" {
+			continue
+		}
+		out = append(out, header{name: name, value: strings.TrimSpace(value)})
+	}
+	return out
 }
 
 func normalize(raw string) (*url.URL, error) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -25,6 +25,10 @@ func fakeTarget() *httptest.Server {
 		w.Header().Set("Content-Security-Policy", "default-src 'self'; frame-ancestors 'none'; base-uri 'self'")
 		io.WriteString(w, "ROW")
 	})
+	// echoes back auth-relevant request headers, to prove injection reaches the target
+	mux.HandleFunc("/app/whoami", func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, r.Header.Get("Cookie")+"|"+r.Header.Get("X-User"))
+	})
 	mux.HandleFunc(adapter.MountPath+"/mocks/card/empty", func(w http.ResponseWriter, _ *http.Request) {
 		io.WriteString(w, `[{"verb":"GET","path":"/app/rows","index":0}]`)
 	})
@@ -79,6 +83,47 @@ func TestOverlayRoutes(t *testing.T) {
 	// reverse proxy passes non-overlay paths straight to the target
 	if got := body(t, ts.URL+"/app/workouts/entry-row"); got != "ROW" {
 		t.Errorf("proxy passthrough = %q", got)
+	}
+}
+
+func TestHeaderInjection(t *testing.T) {
+	target := fakeTarget()
+	defer target.Close()
+	srv, err := New(target.URL, testUI(), "Cookie: session=abc", "X-User: ada", "malformed-no-colon")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	// injected headers reach the target on a proxied (non-overlay) request
+	if got := body(t, ts.URL+"/app/whoami"); got != "session=abc|ada" {
+		t.Errorf("injected headers = %q, want %q", got, "session=abc|ada")
+	}
+
+	// with no headers configured, nothing is added
+	plain, _ := New(target.URL, testUI())
+	pts := httptest.NewServer(plain.Handler())
+	defer pts.Close()
+	if got := body(t, pts.URL+"/app/whoami"); got != "|" {
+		t.Errorf("unexpected headers without injection: %q", got)
+	}
+}
+
+func TestParseHeaders(t *testing.T) {
+	got := parseHeaders([]string{"Cookie: a=b", "X-User:  ada ", "no-colon", "  : empty-name", "Authorization: Bearer x:y"})
+	want := []header{
+		{"Cookie", "a=b"},
+		{"X-User", "ada"},
+		{"Authorization", "Bearer x:y"}, // only the first colon splits; value keeps the rest
+	}
+	if len(got) != len(want) {
+		t.Fatalf("parseHeaders len = %d, want %d (%+v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("header[%d] = %+v, want %+v", i, got[i], want[i])
+		}
 	}
 }
 


### PR DESCRIPTION
## What

In safe/live mode a preview's requests hit the real app, so components behind auth get a `401`/redirect (#15). Add a repeatable `--header 'Name: value'` flag that injects headers (e.g. a session cookie) into every request Swapbook forwards to the target, so protected components render.

```
swapbook --target :8080 --header 'Cookie: session=<dev-session>'
swapbook --target :8080 --header 'Authorization: Bearer <token>' --header 'X-Tenant: acme'
```

Closes #15.

## How

- Injection is done at the **transport layer** (`headerInjector` RoundTripper), not the deprecated `Director`, so the proxy's URL/host/path rewriting is untouched.
- The gallery's own `/_swapbook` fetches use `http.Get`, not this proxy, so they're unaffected.
- Global by design: one credential for the session, no per-story auth (documented as an honest edge).

## Verified end to end against a real app (go-gym)

| Path | Result |
|------|--------|
| direct `/app`, no cookie | 303 → login |
| direct `/app`, demo cookie | 200 |
| proxied via swapbook **without** `--header` | 303 |
| proxied via swapbook **with** `--header` | **200** |

Plus `TestHeaderInjection` (real `ReverseProxy` + HTTP: injected headers reach the target, malformed skipped, none added when unset) and `TestParseHeaders`.

## Docs

`cli.md` (flag + "Auth for protected routes"), `docs.html` (flag row + note), README (Shipped list + "Auth is global" limitation; also tightened the "Mocks are stateless" wording so it credits the error-status mocks feature).