### PR TITLE
feat(cli): headless swapbook check for CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,8 +265,8 @@ Datastar probes, verified end to end) · error-status mocks · controls · respo
 viewer · a11y lint · search · deep-links · keyboard nav · copy-as-curl ·
 swap-target and out-of-band highlight · SSE / WebSocket inspector · canvas
 background toggle · custom viewports · auth header injection for live-mode
-previews · per-component autodocs · auto-reload · install via curl / npx /
-go install.
+previews · headless `check` for CI · per-component autodocs · auto-reload ·
+install via curl / npx / go install.
 
 Planned: visual regression, play/interaction functions, Homebrew. Tracked in the
 [roadmap](https://github.com/Aejkatappaja/swapbook/labels/roadmap).

--- a/cmd/swapbook/main.go
+++ b/cmd/swapbook/main.go
@@ -13,9 +13,11 @@ import (
 	"io/fs"
 	"log"
 	"net/http"
+	"os"
 	"runtime/debug"
 	"strings"
 
+	"github.com/Aejkatappaja/swapbook/internal/check"
 	"github.com/Aejkatappaja/swapbook/internal/server"
 )
 
@@ -54,6 +56,13 @@ func (h *headerFlags) Set(v string) error {
 }
 
 func main() {
+	// `swapbook check --target ...` is a headless CI gate: render every story and
+	// exit non-zero on failure. Dispatched before the default server flags.
+	if len(os.Args) > 1 && os.Args[1] == "check" {
+		runCheck(os.Args[2:])
+		return
+	}
+
 	target := flag.String("target", ":8080", "target app address (host:port or URL)")
 	port := flag.String("port", "7007", "port to serve the Swapbook UI on")
 	showVersion := flag.Bool("version", false, "print version and exit")
@@ -82,6 +91,22 @@ func main() {
 		fmt.Printf("auth      injecting %d header(s) into target requests (live/safe mode)\n", len(headers))
 	}
 	log.Fatal(http.ListenAndServe(addr, srv.Handler()))
+}
+
+// runCheck handles `swapbook check`: a headless render smoke over every story,
+// exiting 1 on any failure (or a setup error) so CI can gate on it.
+func runCheck(args []string) {
+	fs := flag.NewFlagSet("check", flag.ExitOnError)
+	target := fs.String("target", ":8080", "target app address (host:port or URL)")
+	fs.Parse(args)
+	failed, err := check.Run(*target, os.Stdout)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "swapbook check:", err)
+		os.Exit(1)
+	}
+	if failed > 0 {
+		os.Exit(1)
+	}
 }
 
 func loadUI() (server.UI, error) {

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -244,6 +244,12 @@ $sb-&gt;<span class="fn">register</span>(<span class="st">"Button"</span>, [
       </tbody>
     </table>
     <div class="note">Previews behind auth: in <code>safe</code>/<code>live</code> mode a preview hits your real app, so protected routes return 401. Pass the credential with <code>--header 'Cookie: session=...'</code> (repeatable) and Swapbook injects it into every proxied request. Use a throwaway dev session, never a production token; it appears in your shell history.</div>
+    <h3>Headless check (CI)</h3>
+    <p><code>swapbook check --target :8080</code> renders every story and variant once and exits non-zero if any fail, so a build can gate on it. It reports one line per variant and fails on an unreachable target, a missing adapter, a non-2xx preview, or an empty render. A render + reachability smoke; visual-diff and a11y gating are tracked separately.</p>
+    <pre><code>swapbook check --target :8080
+<span class="c">  ok   Button · primary
+  FAIL Card · empty: preview 500
+  29 preview(s), 1 failed</span></code></pre>
     <p class="muted">The UI auto-reloads when your app rebuilds and reconnects if the target goes down. All UI assets are served <code>no-store</code>, so a rebuilt binary never serves a stale gallery.</p>
 
     <h2 id="adapters">Adapters <span class="k">// built-in &amp; custom</span></h2>

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -16,6 +16,30 @@ swapbook [flags]
 | `--header` | | Header injected into every request forwarded to the target, as `Name: value`. Repeatable. |
 | `--version` | | Print the version and exit. |
 
+## Headless check (CI)
+
+`swapbook check` renders every story and variant once and exits non-zero if any
+fail, so you can gate a build on it without opening the gallery:
+
+```
+swapbook check --target :8080
+```
+
+It fetches the manifest, requests each `preview`, and reports one line per
+variant, failing on an unreachable target, a missing adapter, a non-2xx preview,
+or an empty render:
+
+```
+swapbook check → http://localhost:8080
+  ok   Button · primary
+  FAIL Card · empty: preview 500
+29 preview(s), 1 failed
+```
+
+In CI, start your app (with the adapter mounted under a dev flag), then run the
+check against it. This is a render + reachability smoke; screenshot/visual-diff
+and an a11y gate are tracked separately.
+
 ## Auth for protected routes
 
 In `safe` and `live` mode a preview's requests hit your real app, so components

--- a/examples/smoke.sh
+++ b/examples/smoke.sh
@@ -48,6 +48,8 @@ for row in "${TARGETS[@]}"; do
   echo "$frame" | grep -q '"GET /ds/row":"/__sb/mock/todo-list/default/0"' && echo "  ✓ mock route mapped" || { echo "  ✗ mock route"; ok=0; }
   echo "$mock" | grep -q 'New task' && echo "  ✓ mock render" || { echo "  ✗ mock render"; ok=0; }
   curl -s -o /dev/null -w "%{http_code}" "http://localhost:$uport/__sb/htmx.min.js" | grep -q 200 && echo "  ✓ embedded htmx served" || { echo "  ✗ embedded htmx"; ok=0; }
+  # headless CI gate: every story/variant must render (exit 0)
+  "$BIN" check --target ":$tport" >/dev/null 2>&1 && echo "  ✓ swapbook check" || { echo "  ✗ swapbook check"; ok=0; }
 
   kill $spid $tpid 2>/dev/null
   wait $spid $tpid 2>/dev/null

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -1,0 +1,116 @@
+// Package check runs a headless render smoke over a target's Swapbook stories,
+// for use in CI. It fetches the manifest and requests every story/variant's
+// preview, reporting any that fail to render. No browser is needed; this is a
+// pure-HTTP gate (render + reachability), a precursor to visual regression.
+package check
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	adapter "github.com/Aejkatappaja/swapbook/adapters/go"
+	"github.com/Aejkatappaja/swapbook/internal/server"
+)
+
+type manifest struct {
+	Stories []struct {
+		ID       string `json:"id"`
+		Name     string `json:"name"`
+		Variants []struct {
+			Name string `json:"name"`
+		} `json:"variants"`
+	} `json:"stories"`
+}
+
+// Run smoke-checks every story/variant preview on the target (":8080",
+// "localhost:8080" or a URL), writing a per-story report to out. It returns the
+// number of failures; a non-nil error is a setup failure (unreachable target,
+// no adapter, malformed manifest) and should also fail the build.
+func Run(target string, out io.Writer) (int, error) {
+	base, err := server.Normalize(target)
+	if err != nil {
+		return 0, fmt.Errorf("bad target %q: %w", target, err)
+	}
+	root := base.String() + adapter.MountPath
+	cli := &http.Client{Timeout: 15 * time.Second}
+
+	resp, err := cli.Get(root + "/manifest.json")
+	if err != nil {
+		return 0, fmt.Errorf("target unreachable at %s: %w", base, err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return 0, fmt.Errorf("no adapter mounted at %s (manifest 404)", root)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("manifest returned %d", resp.StatusCode)
+	}
+	var m manifest
+	if err := json.Unmarshal(body, &m); err != nil {
+		return 0, fmt.Errorf("manifest is not valid JSON: %w", err)
+	}
+
+	// Flatten to a work list so previews can be checked concurrently while the
+	// report stays in manifest order (each result is written to its own index).
+	type item struct{ id, name, variant, detail string }
+	var items []item
+	for _, s := range m.Stories {
+		for _, v := range s.Variants {
+			items = append(items, item{id: s.ID, name: s.Name, variant: v.Name})
+		}
+	}
+	sem := make(chan struct{}, maxConcurrent)
+	var wg sync.WaitGroup
+	for i := range items {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(i int) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			items[i].detail = checkPreview(cli, root, items[i].id, items[i].variant)
+		}(i)
+	}
+	wg.Wait()
+
+	fmt.Fprintf(out, "swapbook check → %s\n", base)
+	failed := 0
+	for _, it := range items {
+		if it.detail == "" {
+			fmt.Fprintf(out, "  ok   %s · %s\n", it.name, it.variant)
+		} else {
+			failed++
+			fmt.Fprintf(out, "  FAIL %s · %s: %s\n", it.name, it.variant, it.detail)
+		}
+	}
+	fmt.Fprintf(out, "%d preview(s), %d failed\n", len(items), failed)
+	return failed, nil
+}
+
+// maxConcurrent bounds in-flight preview requests so a large gallery checks fast
+// without opening a connection per story.
+const maxConcurrent = 8
+
+// checkPreview requests one preview and returns "" on success or a short reason
+// it failed to render (non-2xx, empty body, or unreachable).
+func checkPreview(cli *http.Client, root, id, variant string) string {
+	resp, err := cli.Get(root + "/preview/" + url.PathEscape(id) + "/" + url.PathEscape(variant))
+	if err != nil {
+		return "unreachable: " + err.Error()
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Sprintf("preview %d", resp.StatusCode)
+	}
+	if len(strings.TrimSpace(string(body))) == 0 {
+		return "empty response"
+	}
+	return ""
+}

--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -1,0 +1,63 @@
+package check
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	adapter "github.com/Aejkatappaja/swapbook/adapters/go"
+)
+
+// fakeTarget serves a manifest with three variants: one renders, one 500s, one
+// returns an empty body.
+func fakeTarget() *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc(adapter.MountPath+"/manifest.json", func(w http.ResponseWriter, _ *http.Request) {
+		io.WriteString(w, `{"stories":[{"id":"card","name":"Card","variants":[{"name":"ok"},{"name":"boom"},{"name":"blank"}]}]}`)
+	})
+	mux.HandleFunc(adapter.MountPath+"/preview/card/ok", func(w http.ResponseWriter, _ *http.Request) {
+		io.WriteString(w, "<div>ok</div>")
+	})
+	mux.HandleFunc(adapter.MountPath+"/preview/card/boom", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "render: boom", http.StatusInternalServerError)
+	})
+	mux.HandleFunc(adapter.MountPath+"/preview/card/blank", func(w http.ResponseWriter, _ *http.Request) {})
+	return httptest.NewServer(mux)
+}
+
+func TestRunReportsFailures(t *testing.T) {
+	ts := fakeTarget()
+	defer ts.Close()
+
+	var out strings.Builder
+	failed, err := Run(ts.URL, &out)
+	if err != nil {
+		t.Fatalf("unexpected setup error: %v", err)
+	}
+	if failed != 2 {
+		t.Errorf("failed = %d, want 2 (boom + blank)", failed)
+	}
+	report := out.String()
+	for _, want := range []string{"ok   Card · ok", "FAIL Card · boom: preview 500", "FAIL Card · blank: empty response", "3 preview(s), 2 failed"} {
+		if !strings.Contains(report, want) {
+			t.Errorf("report missing %q\n%s", want, report)
+		}
+	}
+}
+
+func TestRunNoAdapter(t *testing.T) {
+	// a bare server with nothing mounted under /_swapbook -> manifest 404
+	ts := httptest.NewServer(http.NotFoundHandler())
+	defer ts.Close()
+	if _, err := Run(ts.URL, io.Discard); err == nil {
+		t.Fatal("expected an error when no adapter is mounted")
+	}
+}
+
+func TestRunUnreachable(t *testing.T) {
+	if _, err := Run("http://127.0.0.1:1", io.Discard); err == nil {
+		t.Fatal("expected an error for an unreachable target")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -43,7 +43,7 @@ type UI struct {
 // the target, so components behind auth render in safe/live mode (e.g. a
 // session cookie). Malformed entries (no colon) are ignored.
 func New(raw string, ui UI, headers ...string) (*Server, error) {
-	t, err := normalize(raw)
+	t, err := Normalize(raw)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func parseHeaders(raw []string) []header {
 	return out
 }
 
-func normalize(raw string) (*url.URL, error) {
+func Normalize(raw string) (*url.URL, error) {
 	if !strings.Contains(raw, "://") {
 		if strings.HasPrefix(raw, ":") {
 			raw = "localhost" + raw

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -219,12 +219,12 @@ func TestNormalize(t *testing.T) {
 		"http://example.com:123": "http://example.com:123",
 	}
 	for in, want := range cases {
-		u, err := normalize(in)
+		u, err := Normalize(in)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if u.String() != want {
-			t.Errorf("normalize(%q) = %q, want %q", in, u.String(), want)
+			t.Errorf("Normalize(%q) = %q, want %q", in, u.String(), want)
 		}
 	}
 }


### PR DESCRIPTION
## What

Adds `swapbook check --target ...`, a headless CI gate (#35). It fetches the manifest, renders every story/variant `preview`, and exits non-zero if any fail, so a build can block on it, no browser required.

```
swapbook check → http://localhost:8080
  ok   Button · primary
  FAIL Card · empty: preview 500
29 preview(s), 1 failed
```

Fails on: unreachable target, missing adapter (manifest 404), non-2xx preview, or an empty render. Previews are checked concurrently (bounded to 8) while the report stays in manifest order.

Closes #35.

## Why
Makes Swapbook usable in CI as a render + reachability smoke right now, without waiting for full visual regression (#12), which builds on this.

## Notes
- Exports `server.Normalize` so the check parses the target address (`:8080` / `localhost:8080` / URL) identically to the server.
- Story id and variant are URL-escaped in the preview path.
- Known limits (documented): a zero-story manifest reports success; a legitimately-empty render is flagged. Visual-diff and an a11y gate are tracked separately.

## Post-review
Ran `/code-review` (removed an em-dash from output/docs per repo rule; added URL-escaping) and `/simplify` (parallelized the preview fetches with ordered output; reuse/altitude/simplification otherwise clean).

## Tests
- `internal/check`: renders ok / 500 / empty, plus no-adapter and unreachable setup errors, under `-race`.
- Verified live against `examples/go`: 29 previews, exit 0; dead target, exit 1.

Verified: gofmt/vet/build/`test -race` (20), golangci-lint 0, jsdom 24, UI typecheck.