### PR TITLE
feat: play functions (scripted interactions + assertions per story)

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,10 +266,11 @@ Datastar probes, verified end to end) · error-status mocks · controls · respo
 viewer · a11y lint · search · deep-links · keyboard nav · copy-as-curl ·
 swap-target and out-of-band highlight · SSE / WebSocket inspector · canvas
 background toggle · custom viewports · auth header injection for live-mode
-previews · headless `check` for CI · visual regression · per-component autodocs ·
-auto-reload · install via curl / npx / go install.
+previews · headless `check` for CI · visual regression · play functions
+(scripted interactions + assertions) · per-component autodocs · auto-reload ·
+install via curl / npx / go install.
 
-Planned: play/interaction functions, Homebrew. Tracked in the
+Planned: Homebrew tap. Tracked in the
 [roadmap](https://github.com/Aejkatappaja/swapbook/labels/roadmap).
 
 ## Status

--- a/SPEC.md
+++ b/SPEC.md
@@ -54,6 +54,24 @@ Returns the gallery contents and asset hints.
 }
 ```
 
+A variant may be a bare name string (above) or an object carrying optional
+metadata: `{ "name", "controls", "docs", "play" }`. `play` is a list of
+declarative steps the UI can run against the rendered preview to drive and
+verify a flow, each `{ "action", "target"?, "value"?, "text"? }`:
+
+```jsonc
+"play": [
+  { "action": "click",         "target": "#save" },
+  { "action": "type",          "target": "#email", "value": "a@b.c" },
+  { "action": "expect-text",   "target": "#msg", "text": "saved" },
+  { "action": "expect-visible","target": "#row" },
+  { "action": "wait",          "target": "#row" }
+]
+```
+
+Steps are data, not code, so the UI interprets them (no `eval`) and any adapter
+can emit them. Running a play is a UI concern; the protocol only carries it.
+
 ### 2. Preview (required)
 
 ```

--- a/adapters/go/adapter_test.go
+++ b/adapters/go/adapter_test.go
@@ -83,6 +83,38 @@ func TestViewportsInManifest(t *testing.T) {
 	}
 }
 
+// TestPlayInManifest proves a variant's play steps reach the manifest, and that
+// a variant without a play omits the field.
+func TestPlayInManifest(t *testing.T) {
+	reg := New()
+	reg.Register("Todo",
+		Var("default", HTML("<ul id=rows></ul>")).
+			Play(Click(`[hx-get="/row"]`), ExpectText("#rows", "New task")),
+		Var("plain", HTML("<div>x</div>")),
+	)
+	srv := httptest.NewServer(reg.Handler())
+	defer srv.Close()
+
+	resp, _ := http.Get(srv.URL + "/manifest.json")
+	var m manifest
+	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+		t.Fatal(err)
+	}
+	vs := m.Stories[0].Variants
+	if len(vs[0].Play) != 2 {
+		t.Fatalf("play steps = %+v", vs[0].Play)
+	}
+	if vs[0].Play[0].Action != "click" || vs[0].Play[0].Target != `[hx-get="/row"]` {
+		t.Errorf("step 0 = %+v", vs[0].Play[0])
+	}
+	if vs[0].Play[1].Action != "expect-text" || vs[0].Play[1].Text != "New task" {
+		t.Errorf("step 1 = %+v", vs[0].Play[1])
+	}
+	if vs[1].Play != nil {
+		t.Errorf("variant without play should omit it, got %+v", vs[1].Play)
+	}
+}
+
 func TestGlobalMocks(t *testing.T) {
 	reg := New()
 	reg.Mock("GET /shared", HTML("GLOBAL"))

--- a/adapters/go/handler.go
+++ b/adapters/go/handler.go
@@ -31,6 +31,7 @@ type variantMeta struct {
 	Name     string    `json:"name"`
 	Controls []Control `json:"controls,omitempty"`
 	Docs     string    `json:"docs,omitempty"`
+	Play     []Step    `json:"play,omitempty"`
 }
 
 // MockMeta is the wire shape of a variant's mocked route, shared with the
@@ -74,7 +75,7 @@ func (r *Registry) serveManifest(w http.ResponseWriter, _ *http.Request) {
 	for _, s := range r.stories {
 		vs := make([]variantMeta, len(s.Variants))
 		for i, v := range s.Variants {
-			vs[i] = variantMeta{Name: v.Name, Controls: v.Controls, Docs: v.Docs}
+			vs[i] = variantMeta{Name: v.Name, Controls: v.Controls, Docs: v.Docs, Play: v.PlaySteps}
 		}
 		m.Stories = append(m.Stories, storyMeta{
 			ID: s.ID, Name: s.Name, Group: s.Group, Docs: s.Docs, Variants: vs,

--- a/adapters/go/registry.go
+++ b/adapters/go/registry.go
@@ -101,6 +101,32 @@ func (a Args) Bool(k string) bool {
 
 func parseBool(s string) bool { return s == "true" || s == "1" || s == "on" }
 
+// Step is one action in a variant's play: a scripted interaction or assertion
+// run against the rendered preview in the browser. Target is a CSS selector.
+type Step struct {
+	Action string `json:"action"` // click | type | expect-text | expect-visible | wait
+	Target string `json:"target,omitempty"`
+	Value  string `json:"value,omitempty"` // typed text, for "type"
+	Text   string `json:"text,omitempty"`  // expected substring, for "expect-text"
+}
+
+// Click clicks the element at target.
+func Click(target string) Step { return Step{Action: "click", Target: target} }
+
+// Type sets an input's value to value (firing input/change), at target.
+func Type(target, value string) Step { return Step{Action: "type", Target: target, Value: value} }
+
+// ExpectText asserts target's text contains text (waits for it to appear).
+func ExpectText(target, text string) Step {
+	return Step{Action: "expect-text", Target: target, Text: text}
+}
+
+// ExpectVisible asserts target exists and is visible (waits for it).
+func ExpectVisible(target string) Step { return Step{Action: "expect-visible", Target: target} }
+
+// Wait blocks until target appears in the DOM (e.g. after an htmx swap).
+func Wait(target string) Step { return Step{Action: "wait", Target: target} }
+
 // Variant is one rendered state of a component (e.g. "empty", "with-data").
 type Variant struct {
 	Name      string
@@ -109,6 +135,14 @@ type Variant struct {
 	Build     func(Args) Renderer // set for variants with live controls
 	Mocks     []Mock
 	Docs      string // markdown notes shown in the Swapbook docs tab
+	PlaySteps []Step // scripted interactions + assertions, run on demand
+}
+
+// Play attaches a scripted interaction + assertion sequence to the variant, run
+// on demand in the preview so a story can drive and verify a flow. Chainable.
+func (v Variant) Play(steps ...Step) Variant {
+	v.PlaySteps = append(v.PlaySteps, steps...)
+	return v
 }
 
 // Var is a shorthand constructor for a static Variant.

--- a/cmd/swapbook/ui/app.js
+++ b/cmd/swapbook/ui/app.js
@@ -5,7 +5,8 @@
 
 /**
  * @typedef {{ name: string, type: string, default?: unknown, options?: string[] }} Control
- * @typedef {{ name: string, controls?: Control[], docs?: string }} VariantObj
+ * @typedef {{ action: string, target?: string, value?: string, text?: string }} PlayStep
+ * @typedef {{ name: string, controls?: Control[], docs?: string, play?: PlayStep[] }} VariantObj
  * @typedef {string | VariantObj} Variant  variants may be a bare name (hand-rolled targets) or an object
  * @typedef {{ id: string, name: string, group?: string, docs?: string, variants: Variant[] }} Story
  * @typedef {{ name: string, w: string }} Viewport  a project-declared preview width
@@ -49,11 +50,13 @@ try {
 /** @type {{ story: Story, variant: Variant } | null} */ let current = null;
 /** @type {Record<string, any>} */ let args = {};
 let docsView = false; // showing a story's autodocs page
+let frameReady = false; // preview frame's inspector has announced itself (frame:ready)
 /** @type {string | null} */ let manifestRaw = ""; // last manifest body; null = target down
 
 /** @param {Variant} v */ const vName = (v) => (typeof v === "string" ? v : v.name);
 /** @param {Variant} v @returns {Control[]} */ const vControls = (v) => (typeof v === "string" ? [] : v.controls || []);
 /** @param {Variant} v */ const vDocs = (v) => (typeof v === "string" ? "" : v.docs || "");
+/** @param {Variant} v @returns {PlayStep[]} */ const vPlay = (v) => (typeof v === "string" ? [] : v.play || []);
 /** @param {unknown} s */ const esc = (s) => String(s).replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
 /** typed DOM helpers (checkJs-friendly). @param {string} sel @param {ParentNode} [root] @returns {HTMLElement[]} */
 const qsa = (sel, root = document) => /** @type {HTMLElement[]} */ (Array.from(root.querySelectorAll(sel)));
@@ -97,6 +100,7 @@ async function fetchManifest() {
 
 async function boot() {
   renderBars();
+  el("run-play").onclick = runPlay;
   const m = await fetchManifest();
   if (m.state === "ok") {
     applyManifest(m.text);
@@ -174,6 +178,7 @@ function selectVariant(story, v, stateArgs, width) {
   setActiveStory();
   renderControls(vControls(v));
   renderDocs(vDocs(v));
+  el("run-play").hidden = vPlay(v).length === 0;
   // Resolve the viewport once: an explicit width (from the URL) wins, else the
   // one last used for this story, else full. Applied without persisting, since
   // only a deliberate pick should write the story's remembered width.
@@ -186,6 +191,7 @@ function selectDocs(story) {
   docsView = true;
   current = { story, variant: story.variants[0] };
   args = {};
+  el("run-play").hidden = true;
   el("current").innerHTML = `<span class="p">$</span> ${esc(story.name)} · docs`;
   renderControls([]);
   renderDocs("");
@@ -329,6 +335,7 @@ function frameUrl() {
 
 function loadFrame() {
   if (!current) return;
+  frameReady = false; // set true when the frame's inspector announces itself
   el("current").innerHTML =
     `<span class="p">$</span> ${esc(current.story.name)} · ${esc(vName(current.variant))}`;
   clearEvents();
@@ -544,11 +551,46 @@ window.addEventListener("message", (e) => {
   }
   if (msg.event === "frame:ready") return onReady(msg.data || {});
   if (msg.event === "a11y") return onA11y(msg.data || {});
+  if (msg.event.indexOf("play:") === 0) return onPlay(msg);
   if (msg.event.indexOf("stream") === 0) return onStream(msg);
   onNetwork(msg);
 });
 
+// runPlay sends the current variant's play steps into the preview frame; the
+// inspector runs them and streams results back (handled by onPlay).
+function runPlay() {
+  if (!current) return;
+  const steps = vPlay(current.variant);
+  if (!steps.length) return;
+  if (!frameReady) return; // preview still loading; its inspector isn't listening yet
+  clearEvents();
+  const info = document.createElement("li");
+  info.className = "evt evt-info";
+  info.innerHTML = `<span class="etag">play</span> <span class="muted">running ${steps.length} step(s)…</span>`;
+  el("events").appendChild(info);
+  el("preview").contentWindow.postMessage({ source: "swapbook-cmd", cmd: "play", steps }, "*");
+}
+
+// onPlay renders one row per play step (pass/fail) plus a final summary.
+function onPlay(msg) {
+  const d = msg.data || {};
+  const li = document.createElement("li");
+  if (msg.event === "play:done") {
+    li.className = "evt evt-info";
+    li.innerHTML = `<span class="etag">play</span> <span class="${d.ok ? "mocked" : "blocked"}">${d.ok ? "✓ passed" : "✗ failed"} ${d.passed}/${d.total}</span>`;
+  } else {
+    li.className = "evt evt-" + (d.ok ? "mock" : "blocked");
+    li.innerHTML = [
+      `<span class="etag">${d.ok ? "✓" : "✗"} ${esc(d.action)}</span>`,
+      d.target ? `<code>${esc(d.target)}</code>` : "",
+      d.detail ? `<span class="blocked">${esc(d.detail)}</span>` : "",
+    ].filter(Boolean).join(" ");
+  }
+  appendEvent(li);
+}
+
 function onReady(data) {
+  frameReady = true;
   clearEvents();
   // htmx is verified end-to-end; the other probes are best-effort, so flag them.
   const libs = (data.libs || []).map((/** @type {string} */ l) => (l === "htmx" ? l : l + " (beta)"));

--- a/cmd/swapbook/ui/index.html
+++ b/cmd/swapbook/ui/index.html
@@ -59,6 +59,7 @@
         <button class="tab" data-tab="a11y">a11y <span class="badge" id="a11yCount" hidden>0</span></button>
         <button class="tab" data-tab="docs" id="docsTab" hidden>docs</button>
       </div>
+      <button id="run-play" hidden>▶ play</button>
       <button id="clear">clear</button>
     </div>
     <ol id="events" class="panel"></ol>

--- a/cmd/swapbook/ui/inspector.js
+++ b/cmd/swapbook/ui/inspector.js
@@ -386,6 +386,86 @@
     }
   }
 
+  // ---- Play: scripted interactions + assertions ---------------------------
+  // The chrome posts { source: "swapbook-cmd", cmd: "play", steps } into this
+  // frame; we run each step against the DOM and report the outcome back. Steps
+  // are declarative (click / type / expect-text / expect-visible / wait), so no
+  // eval and the vocabulary is shared with the adapters.
+  function q(sel) {
+    try { return document.querySelector(sel); } catch (_) { return null; }
+  }
+  // waitFor polls for target up to ms; resolves with the element once it exists
+  // and (if given) pred(el) holds, else null on timeout.
+  function waitFor(sel, ms, pred) {
+    return new Promise(function (resolve) {
+      var t0 = performance.now();
+      (function poll() {
+        var el = q(sel);
+        if (el && (!pred || pred(el))) return resolve(el);
+        if (performance.now() - t0 > ms) return resolve(null);
+        setTimeout(poll, 50);
+      })();
+    });
+  }
+  async function runStep(s) {
+    if (s.action === "click") {
+      var el = await waitFor(s.target, 2000);
+      if (!el) return "no element at " + s.target;
+      el.click();
+      return "";
+    }
+    if (s.action === "type") {
+      var input = await waitFor(s.target, 2000);
+      if (!input) return "no element at " + s.target;
+      input.value = s.value;
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+      return "";
+    }
+    if (s.action === "wait") {
+      return (await waitFor(s.target, 3000)) ? "" : "timed out waiting for " + s.target;
+    }
+    if (s.action === "expect-visible") {
+      var vis = await waitFor(s.target, 3000);
+      return vis && vis.offsetParent !== null ? "" : (vis ? "not visible" : "not found") + ": " + s.target;
+    }
+    if (s.action === "expect-text") {
+      if (s.text == null) return "expect-text step has no text";
+      var found = await waitFor(s.target, 3000, function (el) {
+        return (el.textContent || "").indexOf(s.text) !== -1;
+      });
+      return found ? "" : "expected " + s.target + ' to contain "' + s.text + '"';
+    }
+    return "unknown action: " + s.action;
+  }
+  var playing = false;
+  async function runPlay(steps) {
+    playing = true;
+    var passed = 0;
+    try {
+      for (var i = 0; i < steps.length; i++) {
+        var detail = "";
+        try {
+          detail = await runStep(steps[i]);
+        } catch (e) {
+          detail = String((e && e.message) || e);
+        }
+        var ok = detail === "";
+        send("play:result", { index: i, action: steps[i].action, target: steps[i].target, ok: ok, detail: detail });
+        if (ok) passed++;
+        else break; // stop at the first failure, like a test
+      }
+      send("play:done", { passed: passed, total: steps.length, ok: passed === steps.length });
+    } finally {
+      playing = false;
+    }
+  }
+  window.addEventListener("message", function (e) {
+    var m = e.data;
+    // ignore a re-entrant run while one is already in flight
+    if (m && m.source === "swapbook-cmd" && m.cmd === "play" && !playing) runPlay(m.steps || []);
+  });
+
   // ---- Wire up ------------------------------------------------------------
 
   var PROBES = [htmxProbe, turboProbe, unpolyProbe, datastarProbe];

--- a/cmd/swapbook/ui/style.css
+++ b/cmd/swapbook/ui/style.css
@@ -143,13 +143,13 @@ main { position: relative; z-index: 1; display: flex; flex-direction: column; mi
 .seg-label { color: var(--comment); font-size: 11px; }
 .modes, .widths, .bgs { display: flex; gap: 4px; }
 
-.widths button, .modes button, .bgs button, #clear, #open-tab, #copy-link {
+.widths button, .modes button, .bgs button, #clear, #run-play, #open-tab, #copy-link {
   background: var(--bg-elev); border: 1px solid var(--border); color: var(--fg-dim);
   font: inherit; font-size: 12px; padding: 3px 10px; border-radius: var(--r);
   cursor: pointer; transition: border-color var(--t), color var(--t), background var(--t);
 }
 .widths button:hover, .modes button:hover, .bgs button:hover,
-#clear:hover, #open-tab:hover, #copy-link:hover {
+#clear:hover, #run-play:hover, #open-tab:hover, #copy-link:hover {
   color: var(--fg-bright); border-color: var(--cyan);
 }
 .widths button.active, .bgs button.active { color: var(--fg-bright); border-color: var(--cyan); background: var(--bg-cursor); }
@@ -239,7 +239,8 @@ main { position: relative; z-index: 1; display: flex; flex-direction: column; mi
   padding: 6px 12px; font-size: 12px;
   border-bottom: 1px solid var(--border);
 }
-.ins-head #clear { margin-left: auto; }
+.ins-head #run-play, .ins-head #clear { margin-left: auto; }
+#run-play { color: var(--sage); }
 .tabs { display: flex; gap: 3px; }
 .tab {
   background: none; border: 0; color: var(--comment); font: inherit; font-size: 12px;

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -120,6 +120,7 @@
     <a href="#controls">Controls</a>
     <a href="#mocks">Mocks</a>
     <a href="#modes">Modes</a>
+    <a href="#play">Play</a>
     <div class="grp">reference</div>
     <a href="#cli">CLI</a>
     <a href="#visual">Visual regression</a>
@@ -234,6 +235,16 @@ $sb-&gt;<span class="fn">register</span>(<span class="st">"Button"</span>, [
     </table>
     <p class="muted">A request already rerouted to a mock is never blocked; a non-mutating <code>GET</code> is never blocked.</p>
     <p>The inspector normalizes htmx and, best effort, Turbo / Unpoly / Datastar. Long-lived <b>SSE and WebSocket</b> connections get their own lens: open, each message (with direction), and close are logged, so streamed updates are traceable even though there is no discrete request.</p>
+
+    <h2 id="play">Play <span class="k">// drive &amp; verify</span></h2>
+    <p>A variant can attach a <b>play</b>: scripted interactions plus assertions so a story drives and verifies a flow, not just renders a state. Hit <b>▶ play</b> and each step runs against the preview, reporting pass or fail. Steps are declarative (<code>click</code>, <code>type</code>, <code>expect-text</code>, <code>expect-visible</code>, <code>wait</code>), authored in the adapter's own language, so no <code>eval</code> and the same vocabulary works across stacks.</p>
+    <pre><code>adapter.<span class="fn">Var</span>(<span class="st">"default"</span>, <span class="fn">TodoList</span>()).
+    <span class="fn">Mock</span>(<span class="st">"GET /ds/row"</span>, <span class="fn">TodoRow</span>()).
+    <span class="fn">Play</span>(
+        adapter.<span class="fn">Click</span>(<span class="st">`[hx-get="/ds/row"]`</span>),
+        adapter.<span class="fn">ExpectText</span>(<span class="st">"#rows"</span>, <span class="st">"New task"</span>),
+    )</code></pre>
+    <p class="muted">Assertions poll for a few seconds, so a check after a click sees the htmx swap. A play stops at the first failing step, and pairs naturally with mock mode (drive the flow with no auth or DB).</p>
 
     <h2 id="cli">CLI <span class="k">// flags</span></h2>
     <table>

--- a/docs/guide/controls-mocks-modes.md
+++ b/docs/guide/controls-mocks-modes.md
@@ -100,3 +100,29 @@ to htmx requests fired from inside a story:
 The gating runs in the injected inspector, which normalizes htmx (and, best
 effort, Turbo / Unpoly / Datastar) request lifecycles. A request already
 rerouted to a mock is never blocked; a non-mutating `GET` is never blocked.
+
+## Play (scripted interactions + assertions)
+
+A variant can attach a **play**: a sequence of interactions and assertions so a
+story drives and verifies a flow, not just renders a state. Hit **▶ play** in
+the inspector and each step runs against the preview, reporting pass or fail.
+
+Steps are declarative (`click`, `type`, `expect-text`, `expect-visible`,
+`wait`), authored in your adapter's own language rather than JS, so there is no
+`eval` and the same vocabulary works across stacks. In Go:
+
+```go
+reg.RegisterIn("interactive", "Todo list",
+    adapter.Var("default", TodoList()).
+        Mock("GET /ds/row", TodoRow()).
+        Play(
+            adapter.Click(`[hx-get="/ds/row"]`),
+            adapter.ExpectText("#rows", "New task"),
+        ),
+)
+```
+
+Assertions wait: `ExpectText` / `ExpectVisible` / `Wait` poll for a few seconds,
+so an assertion after a click sees the result of the htmx swap. A play stops at
+the first failing step. It pairs naturally with mock mode, drive the flow with
+canned responses, no auth or DB.

--- a/examples/go/main.go
+++ b/examples/go/main.go
@@ -175,7 +175,11 @@ func registry() *adapter.Registry {
 	reg.RegisterIn("interactive", "Todo list",
 		adapter.Var("default", render(todoT, nil)).
 			Mock("GET /ds/row", render(rowT, nil)).
-			Doc("Click **+ add row**: the mock returns a new `<li>` htmx appends. Watch the swap-target flash in the inspector."),
+			Play(
+				adapter.Click(`[hx-get="/ds/row"]`),
+				adapter.ExpectText("#rows", "New task"),
+			).
+			Doc("Click **+ add row**: the mock returns a new `<li>` htmx appends. Watch the swap-target flash in the inspector. Hit **▶ play** to run that interaction and assert the row was added."),
 	)
 
 	reg.RegisterIn("interactive", "Form validation",

--- a/test/e2e/target/main.go
+++ b/test/e2e/target/main.go
@@ -59,6 +59,15 @@ const ssePage = `<!doctype html>
 </script>
 </body></html>`
 
+// A minimal page for the play runner: clicking #go updates #out. No library
+// needed, so the test exercises the runner + command channel in a real browser.
+const playPage = `<!doctype html>
+<html><head><meta charset="utf-8"></head>
+<body>
+<button id="go" onclick="document.getElementById('out').textContent = 'clicked'">go</button>
+<div id="out">idle</div>
+</body></html>`
+
 func registry() *adapter.Registry {
 	reg := adapter.New()
 	// A mocked GET (should reroute) and an unmocked POST (should be blocked).
@@ -72,6 +81,7 @@ func registry() *adapter.Registry {
 	story("unpoly", unpolyPage)
 	story("datastar", datastarPage)
 	reg.Register("sse", adapter.Var("default", adapter.HTML(ssePage)))
+	reg.Register("play", adapter.Var("default", adapter.HTML(playPage)))
 	return reg
 }
 

--- a/test/e2e/tests/play.spec.js
+++ b/test/e2e/tests/play.spec.js
@@ -1,0 +1,35 @@
+// Drives the inspector's play runner in a real browser: post a play command (as
+// the chrome does), let the inspector run the steps against the real DOM, and
+// assert the results stream back (#14).
+import { test, expect } from "@playwright/test";
+
+test("play: runs steps against the real DOM and reports the outcome", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.__sb = [];
+    addEventListener("message", (e) => {
+      if (e.data && e.data.source === "swapbook") window.__sb.push(e.data);
+    });
+  });
+  await page.goto("/__sb/frame/play/default?mode=mock");
+  await page.waitForLoadState("networkidle");
+
+  await page.evaluate(() =>
+    window.postMessage(
+      {
+        source: "swapbook-cmd",
+        cmd: "play",
+        steps: [
+          { action: "click", target: "#go" },
+          { action: "expect-text", target: "#out", text: "clicked" },
+        ],
+      },
+      "*",
+    ),
+  );
+
+  await expect
+    .poll(() => page.evaluate(() => window.__sb.find((m) => m.event === "play:done")?.data.ok))
+    .toBe(true);
+  const results = await page.evaluate(() => window.__sb.filter((m) => m.event === "play:result").map((m) => m.data.ok));
+  expect(results).toEqual([true, true]);
+});

--- a/test/ui/inspector-probes.test.mjs
+++ b/test/ui/inspector-probes.test.mjs
@@ -106,6 +106,50 @@ test("SSE: open, message and close are streamed to the chrome", async () => {
   sb.close();
 });
 
+// ---- Play (scripted interactions + assertions) ----------------------------
+
+const waitForDone = async (sb) => {
+  for (let i = 0; i < 400 && sb.events("play:done").length === 0; i++) {
+    await new Promise((r) => setTimeout(r, 10));
+  }
+};
+const play = (sb, steps) =>
+  sb.w.dispatchEvent(new sb.w.MessageEvent("message", { data: { source: "swapbook-cmd", cmd: "play", steps } }));
+
+test("play: runs click + assertion and reports all steps passing", async () => {
+  const sb = await loadInspector({ body: '<ul id="rows"></ul><button id="add">add</button>' });
+  // simulate the swap a click would trigger
+  sb.w.document.getElementById("add").addEventListener("click", () => {
+    sb.w.document.getElementById("rows").innerHTML = "<li>New task</li>";
+  });
+  play(sb, [
+    { action: "click", target: "#add" },
+    { action: "expect-text", target: "#rows", text: "New task" },
+  ]);
+  await waitForDone(sb);
+  const done = sb.events("play:done")[0].data;
+  assert.equal(done.ok, true);
+  assert.equal(done.passed, 2);
+  assert.equal(sb.events("play:result").length, 2);
+  assert.ok(sb.events("play:result").every((r) => r.data.ok));
+  sb.close();
+});
+
+test("play: stops at the first failing assertion", async () => {
+  const sb = await loadInspector({ body: '<div id="out">nope</div>' });
+  play(sb, [
+    { action: "expect-text", target: "#out", text: "yes" }, // fails (polls, then gives up)
+    { action: "click", target: "#never" }, // never reached
+  ]);
+  await waitForDone(sb);
+  const done = sb.events("play:done")[0].data;
+  assert.equal(done.ok, false);
+  assert.equal(done.passed, 0);
+  assert.equal(sb.events("play:result").length, 1);
+  assert.equal(sb.events("play:result")[0].data.ok, false);
+  sb.close();
+});
+
 test("WebSocket: send and receive are tagged by direction", async () => {
   const sb = await loadInspector({ libs: ["htmx"] });
   const ws = new sb.w.WebSocket("ws://localhost/app/ws");


### PR DESCRIPTION
## What

A variant can attach a **play**: interactions + assertions run on demand against the preview, so a story can drive and verify a flow, not just render a state (#14).

```go
adapter.Var("default", TodoList()).
    Mock("GET /ds/row", TodoRow()).
    Play(
        adapter.Click(`[hx-get="/ds/row"]`),
        adapter.ExpectText("#rows", "New task"),
    )
```

Hit **▶ play** in the inspector → each step runs, reporting pass/fail; the play stops at the first failure.

## Design

- **Declarative steps, not JS.** `click` / `type` / `expect-text` / `expect-visible` / `wait`, authored in the adapter's own language, serialized in the manifest. No `eval`; the same vocabulary works for any adapter (the protocol just carries it). Storybook uses JS play fns because Storybook is JS; Swapbook is language-agnostic, so steps-as-data is the right altitude.
- **Runner lives in the inspector** (the only place with the live preview DOM). The chrome posts `{source:"swapbook-cmd", cmd:"play", steps}` into the frame; results stream back via the existing `send()` channel. Assertions poll for a few seconds, so a check after a click sees the htmx swap.
- MVP scope: Go adapter + core actions; other adapters + more actions can follow.

## Tests
- Go: play steps reach the manifest (and omit when absent).
- jsdom: the runner passes a click+assert flow and stops at the first failing assertion.
- e2e: the runner drives a real click + assertion in a real browser.
- Also verified the full chrome path (▶ button → runner → results) manually.

## Post-review
`/code-review` (frame-ready guard, re-entrancy guard, expect-text guard) and `/simplify` (folded `expect-text` into a `waitFor` predicate; reuse/efficiency/altitude clean).

Docs: SPEC (manifest `play` field), README roadmap, the controls/mocks/modes guide, and the site.

Verified: gofmt/vet/build/`test -race` (21), golangci-lint 0, jsdom 26, UI typecheck, e2e 5.