### PR TITLE
feat(adapters): viewports + play for Django, Rails and PHP

### DIFF
--- a/adapters/django/swapbook_adapter.py
+++ b/adapters/django/swapbook_adapter.py
@@ -35,9 +35,38 @@ def mock(route, render, status=200):
     return {"verb": verb.upper(), "path": p or route, "render": render, "status": status}
 
 
-def variant(name, render, controls=None, docs="", mocks=None):
-    """One rendered state. render is a callable (args: dict) -> html str."""
-    return {"name": name, "render": render, "controls": controls or [], "docs": docs, "mocks": mocks or []}
+def viewport(name, w):
+    """A named preview width, added to the built-in full/tablet/phone."""
+    return {"name": name, "w": w}
+
+
+# Play steps: scripted interactions + assertions run against the preview.
+def click(target):
+    return {"action": "click", "target": target}
+
+
+def type_(target, value):
+    return {"action": "type", "target": target, "value": value}
+
+
+def expect_text(target, text):
+    return {"action": "expect-text", "target": target, "text": text}
+
+
+def expect_visible(target):
+    return {"action": "expect-visible", "target": target}
+
+
+def wait(target):
+    return {"action": "wait", "target": target}
+
+
+def variant(name, render, controls=None, docs="", mocks=None, play=None):
+    """One rendered state. render is a callable (args: dict) -> html str.
+
+    play is an optional list of steps (see click/type_/expect_text/...) run on
+    demand against the preview."""
+    return {"name": name, "render": render, "controls": controls or [], "docs": docs, "mocks": mocks or [], "play": play or []}
 
 
 def _coerce(controls, GET):
@@ -62,8 +91,9 @@ def _coerce(controls, GET):
 
 
 class Registry:
-    def __init__(self, htmx_src="", css_src="", js_src=""):
+    def __init__(self, htmx_src="", css_src="", js_src="", viewports=None):
         self.htmx_src, self.css_src, self.js_src = htmx_src, css_src, js_src
+        self.viewports = viewports or []
         self._stories = []
         self._global_mocks = []
 
@@ -99,13 +129,22 @@ class Registry:
         ]
 
     def _manifest(self, request):
-        return JsonResponse({
+        def vmeta(v):
+            m = {"name": v["name"], "controls": v["controls"], "docs": v["docs"]}
+            if v.get("play"):
+                m["play"] = v["play"]
+            return m
+
+        out = {
             "htmxSrc": self.htmx_src, "cssSrc": self.css_src, "jsSrc": self.js_src,
             "stories": [{
                 "id": s["id"], "name": s["name"], "group": s["group"], "docs": s["docs"],
-                "variants": [{"name": v["name"], "controls": v["controls"], "docs": v["docs"]} for v in s["variants"]],
+                "variants": [vmeta(v) for v in s["variants"]],
             } for s in self._stories],
-        })
+        }
+        if self.viewports:
+            out["viewports"] = self.viewports
+        return JsonResponse(out)
 
     def _preview(self, request, sid, vname):
         v = self._find(sid, vname)

--- a/adapters/php/swapbook.php
+++ b/adapters/php/swapbook.php
@@ -22,9 +22,19 @@ function sb_mock(string $route, callable $render, int $status = 200): array
     return ['verb' => strtoupper($verb), 'path' => $path, 'render' => $render, 'status' => $status];
 }
 
-function sb_variant(string $name, callable $render, array $controls = [], string $docs = '', array $mocks = []): array
+// A named preview width, added to the built-in full/tablet/phone.
+function sb_viewport(string $name, string $w): array { return ['name' => $name, 'w' => $w]; }
+
+// Play steps: scripted interactions + assertions run against the preview.
+function sb_click(string $target): array { return ['action' => 'click', 'target' => $target]; }
+function sb_type(string $target, string $value): array { return ['action' => 'type', 'target' => $target, 'value' => $value]; }
+function sb_expect_text(string $target, string $text): array { return ['action' => 'expect-text', 'target' => $target, 'text' => $text]; }
+function sb_expect_visible(string $target): array { return ['action' => 'expect-visible', 'target' => $target]; }
+function sb_wait(string $target): array { return ['action' => 'wait', 'target' => $target]; }
+
+function sb_variant(string $name, callable $render, array $controls = [], string $docs = '', array $mocks = [], array $play = []): array
 {
-    return compact('name', 'render', 'controls', 'docs', 'mocks');
+    return compact('name', 'render', 'controls', 'docs', 'mocks', 'play');
 }
 
 class Swapbook
@@ -34,6 +44,8 @@ class Swapbook
     public string $htmxSrc = '';
     public string $cssSrc = '';
     public string $jsSrc = '';
+    /** @var array<array{name:string,w:string}> named preview widths */
+    public array $viewports = [];
 
     public function register(string $name, array $variants, string $group = '', string $docs = ''): void
     {
@@ -128,13 +140,24 @@ class Swapbook
 
     private function manifest(): array
     {
-        return [
+        $vmeta = function ($v) {
+            $m = ['name' => $v['name'], 'controls' => $v['controls'], 'docs' => $v['docs']];
+            if (!empty($v['play'])) {
+                $m['play'] = $v['play'];
+            }
+            return $m;
+        };
+        $out = [
             'htmxSrc' => $this->htmxSrc, 'cssSrc' => $this->cssSrc, 'jsSrc' => $this->jsSrc,
             'stories' => array_map(fn($s) => [
                 'id' => $s['id'], 'name' => $s['name'], 'group' => $s['group'], 'docs' => $s['docs'],
-                'variants' => array_map(fn($v) => ['name' => $v['name'], 'controls' => $v['controls'], 'docs' => $v['docs']], $s['variants']),
+                'variants' => array_map($vmeta, $s['variants']),
             ], $this->stories),
         ];
+        if ($this->viewports) {
+            $out['viewports'] = $this->viewports;
+        }
+        return $out;
     }
 
     private function json(array $o): array { return [200, 'application/json', json_encode($o)]; }

--- a/adapters/php/swapbook_test.php
+++ b/adapters/php/swapbook_test.php
@@ -75,6 +75,23 @@ $sb3->register('Form', [
 [$st, , $body] = $sb3->handle('POST', '/_swapbook/mock/form/invalid/0', []);
 check($st === 422 && $body === '<div>invalid</div>', 'mock render honors status');
 
+// viewports + play reach the manifest (and are omitted when unset)
+$sb4 = new Swapbook();
+$sb4->viewports = [sb_viewport('wide', '1440px')];
+$sb4->register('Todo', [
+    sb_variant('default', fn($a) => '<ul id="rows"></ul>', [], '', [], [
+        sb_click('[hx-get="/row"]'),
+        sb_expect_text('#rows', 'New task'),
+    ]),
+    sb_variant('plain', fn($a) => '<div>x</div>'),
+]);
+[, , $body] = $sb4->handle('GET', '/_swapbook/manifest.json', []);
+$m4 = json_decode($body, true);
+check(($m4['viewports'][0]['name'] ?? '') === 'wide' && ($m4['viewports'][0]['w'] ?? '') === '1440px', 'viewports in manifest');
+$pv = $m4['stories'][0]['variants'][0]['play'] ?? [];
+check(count($pv) === 2 && ($pv[0]['action'] ?? '') === 'click' && ($pv[1]['text'] ?? '') === 'New task', 'play steps in manifest');
+check(!isset($m4['stories'][0]['variants'][1]['play']), 'variant without play omits it');
+
 // unknown routes -> 404
 [$st] = $sb->handle('GET', '/_swapbook/preview/nope/nope', []);
 check($st === 404, 'unknown preview 404');

--- a/adapters/rails/swapbook.rb
+++ b/adapters/rails/swapbook.rb
@@ -22,13 +22,24 @@ module Swapbook
     { verb: verb.upcase, path: path, render: render, status: status }
   end
 
-  def self.variant(name, render, controls: [], docs: "", mocks: [])
-    { name: name, render: render, controls: controls, docs: docs, mocks: mocks }
+  # A named preview width, added to the built-in full/tablet/phone.
+  def self.viewport(name, w) = { name: name, w: w }
+
+  # Play steps: scripted interactions + assertions run against the preview.
+  def self.click(target) = { action: "click", target: target }
+  def self.type(target, value) = { action: "type", target: target, value: value }
+  def self.expect_text(target, text) = { action: "expect-text", target: target, text: text }
+  def self.expect_visible(target) = { action: "expect-visible", target: target }
+  def self.wait(target) = { action: "wait", target: target }
+
+  def self.variant(name, render, controls: [], docs: "", mocks: [], play: [])
+    { name: name, render: render, controls: controls, docs: docs, mocks: mocks, play: play }
   end
 
   class Registry
-    def initialize(htmx_src: "", css_src: "", js_src: "")
+    def initialize(htmx_src: "", css_src: "", js_src: "", viewports: [])
       @htmx_src, @css_src, @js_src = htmx_src, css_src, js_src
+      @viewports = viewports
       @stories = []
       @global_mocks = []
     end
@@ -69,15 +80,23 @@ module Swapbook
     private
 
     def manifest
-      {
+      m = {
         htmxSrc: @htmx_src, cssSrc: @css_src, jsSrc: @js_src,
         stories: @stories.map { |s|
           {
             id: s[:id], name: s[:name], group: s[:group], docs: s[:docs],
-            variants: s[:variants].map { |v| { name: v[:name], controls: v[:controls], docs: v[:docs] } },
+            variants: s[:variants].map { |v| vmeta(v) },
           }
         },
       }
+      m[:viewports] = @viewports unless @viewports.empty?
+      m
+    end
+
+    def vmeta(v)
+      m = { name: v[:name], controls: v[:controls], docs: v[:docs] }
+      m[:play] = v[:play] if v[:play] && !v[:play].empty?
+      m
     end
 
     def find(sid, vname)

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -159,7 +159,7 @@ reg.<span class="fn">RegisterIn</span>(<span class="st">"actions"</span>, <span 
     adapter.<span class="fn">Var</span>(<span class="st">"secondary"</span>, <span class="fn">Button</span>(<span class="st">"Cancel"</span>, <span class="st">"secondary"</span>)),
 )
 reg.<span class="fn">DocStory</span>(<span class="st">"Button"</span>, <span class="st">"The button primitive."</span>)</code></pre>
-    <p class="muted">Viewports set via <code>reg.Viewports</code> appear in the toolbar's width bar next to the built-in full/tablet/phone, and the width you pick is remembered per story. Other stacks emit the same <code>viewports</code> list in their manifest.</p>
+    <p class="muted">Viewports set via <code>reg.Viewports</code> appear in the toolbar's width bar next to the built-in full/tablet/phone, and the width you pick is remembered per story. Other stacks take a <code>viewports</code> arg on the registry too (Django/Rails/PHP).</p>
 
     <h3>Django</h3>
     <pre><code><span class="kw">from</span> swapbook_adapter <span class="kw">import</span> Registry, variant

--- a/docs/guide/controls-mocks-modes.md
+++ b/docs/guide/controls-mocks-modes.md
@@ -122,6 +122,10 @@ reg.RegisterIn("interactive", "Todo list",
 )
 ```
 
+The other stacks take a `play` list with matching step helpers: `play=[click(...),
+expect_text(...)]` in Django, `play: [Swapbook.click(...), ...]` in Rails, and a
+`$play` argument with `sb_click(...)` / `sb_expect_text(...)` in PHP.
+
 Assertions wait: `ExpectText` / `ExpectVisible` / `Wait` poll for a few seconds,
 so an assertion after a click sees the result of the htmx swap. A play stops at
 the first failing step. It pairs naturally with mock mode, drive the flow with


### PR DESCRIPTION
## What

Custom viewports (#13) and play functions (#14) shipped Go-first. This brings **Django, Rails and PHP** to parity.

Each adapter gains:
- a `viewports` arg on the registry + a `viewport(name, w)` helper
- a `play` list on the variant + step helpers (`click` / `type` / `expect_text` / `expect_visible` / `wait`)
- both emitted in the manifest, omitted when unset (mirrors Go's `omitempty`)

The inspector runner + chrome already consume any adapter's manifest `play`/`viewports`, so this is purely adapter-side.

## Per stack
- **Django**: `Registry(viewports=[...])`, `variant(..., play=[click(...), expect_text(...)])`.
- **Rails**: `Registry.new(viewports: [...])`, `Swapbook.variant(..., play: [Swapbook.click(...), ...])`.
- **PHP**: `$sb->viewports = [...]`, `sb_variant(..., $play)` with `sb_click(...)` etc.

## Tests
- PHP adapter test: asserts viewports + play reach the manifest, and are omitted when unset.
- Verified: PHP test suite passes, Ruby 3.2 + Python syntax check clean. (Go parity already covered by its own tests.)

Docs: the play guide notes the per-stack API; the site's viewports note updated.