### PR TITLE
feat(adapters): Flask and Express adapters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
           if-no-files-found: ignore
 
   smoke:
-    name: protocol smoke (python/node/ruby/flask/express)
+    name: protocol smoke (python/node/ruby)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
           if-no-files-found: ignore
 
   smoke:
-    name: protocol smoke (python/node/ruby)
+    name: protocol smoke (python/node/ruby/flask/express)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -136,4 +136,6 @@ jobs:
         with:
           ruby-version: "3.2"
       - run: gem install webrick --no-document # dropped from Ruby's default gems in 3.0
+      - run: pip install flask # for the Flask adapter demo
+      - run: npm install --prefix examples/express # express, for the Express adapter demo
       - run: bash examples/smoke.sh

--- a/README.md
+++ b/README.md
@@ -275,9 +275,9 @@ Planned: Homebrew tap. Tracked in the
 
 ## Status
 
-Early. The protocol is proven across seven stacks with tests: Go/templ, Django,
-Rails and Laravel via adapters, plus dependency-free Python, Node and Ruby
-targets. Interfaces may still shift before a tagged release.
+Early. The protocol is proven across nine stacks with tests: Go/templ, Django,
+Rails, Laravel, Flask and Express via adapters, plus dependency-free Python,
+Node and Ruby targets. Interfaces may still shift before a tagged release.
 
 ## Limitations
 

--- a/adapters/express/swapbook.js
+++ b/adapters/express/swapbook.js
@@ -1,0 +1,139 @@
+"use strict";
+// Swapbook adapter for Express.
+//
+// Exposes the Swapbook protocol (manifest / preview / mocks / mock) as an
+// Express router. Render-agnostic: a variant's render is (args) => htmlString,
+// so it works with any template engine or raw strings. Mount it:
+//   app.use(registry.router());
+const express = require("express");
+
+function slug(s) {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");
+}
+
+function splitRoute(route) {
+  const i = route.indexOf(" ");
+  return i === -1 ? ["GET", route] : [route.slice(0, i), route.slice(i + 1)];
+}
+
+function control(name, type = "text", def = null, options) {
+  const c = { name, type, default: def };
+  if (options) c.options = options;
+  return c;
+}
+
+// Pass a non-2xx status (422, 500, ...) to preview a component's error state.
+function mock(route, render, status = 200) {
+  const [verb, path] = splitRoute(route);
+  return { verb: verb.toUpperCase(), path, render, status };
+}
+
+// A named preview width, added to the built-in full/tablet/phone.
+function viewport(name, w) {
+  return { name, w };
+}
+
+// Play steps: scripted interactions + assertions run against the preview.
+function click(target) { return { action: "click", target }; }
+function type(target, value) { return { action: "type", target, value }; }
+function expectText(target, text) { return { action: "expect-text", target, text }; }
+function expectVisible(target) { return { action: "expect-visible", target }; }
+function wait(target) { return { action: "wait", target }; }
+
+function variant(name, render, opts = {}) {
+  return {
+    name, render,
+    controls: opts.controls || [],
+    docs: opts.docs || "",
+    mocks: opts.mocks || [],
+    play: opts.play || [],
+  };
+}
+
+function coerce(controls, query) {
+  const args = {};
+  for (const c of controls) {
+    const raw = query[c.name];
+    if (raw === undefined) { args[c.name] = c.default; continue; } // absent -> default
+    if (c.type === "number") {
+      const n = parseFloat(raw);
+      args[c.name] = Number.isNaN(n) ? c.default : n;
+    } else if (c.type === "bool") {
+      args[c.name] = raw === "true" || raw === "1" || raw === "on";
+    } else {
+      args[c.name] = raw;
+    }
+  }
+  return args;
+}
+
+class Registry {
+  constructor(opts = {}) {
+    this.htmxSrc = opts.htmxSrc || "";
+    this.cssSrc = opts.cssSrc || "";
+    this.jsSrc = opts.jsSrc || "";
+    this.viewports = opts.viewports || [];
+    this._stories = [];
+    this._globalMocks = [];
+  }
+
+  register(name, variants, opts = {}) {
+    this._stories.push({ id: slug(name), name, group: opts.group || "", docs: opts.docs || "", variants });
+    return this;
+  }
+
+  // Registry-level mock merged into every variant; a variant's own mock for the
+  // same route wins.
+  mock(route, render, status = 200) {
+    this._globalMocks.push(mock(route, render, status));
+    return this;
+  }
+
+  _mocksFor(v) { return this._globalMocks.concat(v.mocks); }
+  _find(sid, vname) {
+    const s = this._stories.find((x) => x.id === sid);
+    return s && s.variants.find((v) => v.name === vname);
+  }
+
+  _manifest() {
+    const vmeta = (v) => {
+      const m = { name: v.name, controls: v.controls, docs: v.docs };
+      if (v.play && v.play.length) m.play = v.play;
+      return m;
+    };
+    const out = {
+      htmxSrc: this.htmxSrc, cssSrc: this.cssSrc, jsSrc: this.jsSrc,
+      stories: this._stories.map((s) => ({
+        id: s.id, name: s.name, group: s.group, docs: s.docs,
+        variants: s.variants.map(vmeta),
+      })),
+    };
+    if (this.viewports.length) out.viewports = this.viewports;
+    return out;
+  }
+
+  router() {
+    const r = express.Router();
+    r.get("/_swapbook/manifest.json", (req, res) => res.json(this._manifest()));
+    r.get("/_swapbook/preview/:sid/:vname", (req, res) => {
+      const v = this._find(req.params.sid, req.params.vname);
+      if (!v) return res.sendStatus(404);
+      res.type("html").send(v.render(coerce(v.controls, req.query)));
+    });
+    r.get("/_swapbook/mocks/:sid/:vname", (req, res) => {
+      const v = this._find(req.params.sid, req.params.vname);
+      if (!v) return res.sendStatus(404);
+      res.json(this._mocksFor(v).map((m, i) => ({ verb: m.verb, path: m.path, index: i })));
+    });
+    r.all("/_swapbook/mock/:sid/:vname/:index", (req, res) => {
+      const v = this._find(req.params.sid, req.params.vname);
+      if (!v) return res.sendStatus(404);
+      const mk = this._mocksFor(v)[parseInt(req.params.index, 10)];
+      if (!mk) return res.sendStatus(404);
+      res.status(mk.status || 200).type("html").send(mk.render({}));
+    });
+    return r;
+  }
+}
+
+module.exports = { Registry, control, mock, variant, viewport, click, type, expectText, expectVisible, wait };

--- a/adapters/flask/swapbook.py
+++ b/adapters/flask/swapbook.py
@@ -1,0 +1,167 @@
+"""Swapbook adapter for Flask.
+
+Exposes the Swapbook protocol (manifest / preview / mocks / mock) as a Flask
+blueprint. Render-agnostic: a variant is a callable ``(args) -> str`` returning
+HTML, so it works with Jinja templates or raw strings. Mount it:
+
+    app.register_blueprint(registry.blueprint)
+"""
+import re
+
+from flask import Blueprint, Response, jsonify, request
+
+Args = dict  # {control_name: coerced_value}
+
+
+def slug(s: str) -> str:
+    return re.sub(r"-+", "-", re.sub(r"[^a-z0-9]+", "-", s.lower())).strip("-")
+
+
+def control(name, type="text", default=None, options=None):
+    """Declare an editable control (knob). type: text|number|bool|select."""
+    c = {"name": name, "type": type, "default": default}
+    if options:
+        c["options"] = options
+    return c
+
+
+def mock(route, render, status=200):
+    """A canned response: route is "VERB /path", render is (args)->str. Pass a
+    non-2xx status (422, 500, ...) to preview a component's error state."""
+    verb, _, p = route.partition(" ") if " " in route else ("GET", "", route)
+    return {"verb": verb.upper(), "path": p or route, "render": render, "status": status}
+
+
+def viewport(name, w):
+    """A named preview width, added to the built-in full/tablet/phone."""
+    return {"name": name, "w": w}
+
+
+# Play steps: scripted interactions + assertions run against the preview.
+def click(target):
+    return {"action": "click", "target": target}
+
+
+def type_(target, value):
+    return {"action": "type", "target": target, "value": value}
+
+
+def expect_text(target, text):
+    return {"action": "expect-text", "target": target, "text": text}
+
+
+def expect_visible(target):
+    return {"action": "expect-visible", "target": target}
+
+
+def wait(target):
+    return {"action": "wait", "target": target}
+
+
+def variant(name, render, controls=None, docs="", mocks=None, play=None):
+    """One rendered state. render is a callable (args: dict) -> html str."""
+    return {"name": name, "render": render, "controls": controls or [], "docs": docs, "mocks": mocks or [], "play": play or []}
+
+
+def _coerce(controls, args_get):
+    args = {}
+    for c in controls:
+        name = c["name"]
+        raw = args_get(name)
+        if raw is None:  # absent -> default; present-but-empty is a real value
+            args[name] = c.get("default")
+            continue
+        t = c.get("type")
+        if t == "number":
+            try:
+                args[name] = float(raw)
+            except ValueError:
+                args[name] = c.get("default")
+        elif t == "bool":
+            args[name] = raw in ("true", "1", "on")
+        else:
+            args[name] = raw
+    return args
+
+
+class Registry:
+    def __init__(self, htmx_src="", css_src="", js_src="", viewports=None):
+        self.htmx_src, self.css_src, self.js_src = htmx_src, css_src, js_src
+        self.viewports = viewports or []
+        self._stories = []
+        self._global_mocks = []
+
+    def register(self, name, variants, group="", docs=""):
+        self._stories.append(
+            {"id": slug(name), "name": name, "group": group, "docs": docs, "variants": variants}
+        )
+
+    def mock(self, route, render, status=200):
+        """Registry-level mock merged into every variant. A variant's own mock
+        for the same route wins."""
+        self._global_mocks.append(mock(route, render, status))
+        return self
+
+    def _mocks_for(self, v):
+        return self._global_mocks + v["mocks"]
+
+    def _find(self, sid, vname):
+        for s in self._stories:
+            if s["id"] == sid:
+                for v in s["variants"]:
+                    if v["name"] == vname:
+                        return v
+        return None
+
+    @property
+    def blueprint(self):
+        bp = Blueprint("swapbook", __name__)
+        bp.add_url_rule("/_swapbook/manifest.json", "manifest", self._manifest)
+        bp.add_url_rule("/_swapbook/preview/<sid>/<vname>", "preview", self._preview)
+        bp.add_url_rule("/_swapbook/mocks/<sid>/<vname>", "mocks", self._mocks)
+        bp.add_url_rule(
+            "/_swapbook/mock/<sid>/<vname>/<int:index>", "mock", self._mock,
+            methods=["GET", "POST", "PUT", "DELETE", "PATCH"],
+        )
+        return bp
+
+    def _manifest(self):
+        def vmeta(v):
+            m = {"name": v["name"], "controls": v["controls"], "docs": v["docs"]}
+            if v.get("play"):
+                m["play"] = v["play"]
+            return m
+
+        out = {
+            "htmxSrc": self.htmx_src, "cssSrc": self.css_src, "jsSrc": self.js_src,
+            "stories": [{
+                "id": s["id"], "name": s["name"], "group": s["group"], "docs": s["docs"],
+                "variants": [vmeta(v) for v in s["variants"]],
+            } for s in self._stories],
+        }
+        if self.viewports:
+            out["viewports"] = self.viewports
+        return jsonify(out)
+
+    def _preview(self, sid, vname):
+        v = self._find(sid, vname)
+        if not v:
+            return Response(status=404)
+        return Response(v["render"](_coerce(v["controls"], request.args.get)), mimetype="text/html")
+
+    def _mocks(self, sid, vname):
+        v = self._find(sid, vname)
+        if not v:
+            return Response(status=404)
+        mks = self._mocks_for(v)
+        return jsonify([{"verb": m["verb"], "path": m["path"], "index": i} for i, m in enumerate(mks)])
+
+    def _mock(self, sid, vname, index):
+        v = self._find(sid, vname)
+        if not v:
+            return Response(status=404)
+        mks = self._mocks_for(v)
+        if index < 0 or index >= len(mks):
+            return Response(status=404)
+        mk = mks[index]
+        return Response(mk["render"]({}), status=mk.get("status", 200), mimetype="text/html")

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -193,6 +193,26 @@ $sb-&gt;<span class="fn">register</span>(<span class="st">"Button"</span>, [
 <span class="c">// route /_swapbook/* to:</span>
 [$status, $ct, $body] = $sb-&gt;<span class="fn">handle</span>($method, $path, $query);</code></pre>
 
+    <h3>Flask</h3>
+    <pre><code><span class="kw">from</span> swapbook <span class="kw">import</span> Registry, variant
+
+reg = <span class="fn">Registry</span>(css_src=<span class="st">"/static/app.css"</span>)
+reg.<span class="fn">register</span>(<span class="st">"Button"</span>, [
+    <span class="fn">variant</span>(<span class="st">"primary"</span>, <span class="kw">lambda</span> a: render_button(<span class="st">"Save"</span>)),
+], group=<span class="st">"actions"</span>)
+
+app.<span class="fn">register_blueprint</span>(reg.blueprint)</code></pre>
+
+    <h3>Express</h3>
+    <pre><code><span class="kw">const</span> { Registry, variant } = <span class="fn">require</span>(<span class="st">"swapbook"</span>);
+
+<span class="kw">const</span> reg = <span class="kw">new</span> <span class="fn">Registry</span>({ cssSrc: <span class="st">"/static/app.css"</span> });
+reg.<span class="fn">register</span>(<span class="st">"Button"</span>, [
+    <span class="fn">variant</span>(<span class="st">"primary"</span>, () =&gt; renderButton(<span class="st">"Save"</span>)),
+], { group: <span class="st">"actions"</span> });
+
+app.<span class="fn">use</span>(reg.<span class="fn">router</span>());</code></pre>
+
     <h3>Any other stack</h3>
     <p>There is no adapter requirement. Answer the four endpoints under <code>/_swapbook</code> in any language and Swapbook drives it. See the <a href="#protocol">protocol</a> and the stdlib examples in <code>examples/{python,node,ruby}/</code>.</p>
 

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -274,7 +274,7 @@ docker run --rm -v "$PWD/test/e2e/visual:/work/test/e2e/visual" swapbook-visual 
     <p>Baselines and the comparison run in a pinned Docker image (Playwright + Go) so local and CI renders are byte-identical. On a mismatch, CI uploads an interactive expected/actual/diff report. Full walkthrough in the <a href="https://github.com/Aejkatappaja/swapbook/blob/main/docs/guide/visual-regression.md">visual regression guide</a>.</p>
 
     <h2 id="adapters">Adapters <span class="k">// built-in &amp; custom</span></h2>
-    <p>An adapter is the small render-agnostic piece in your app that answers the protocol. Built-in adapters live under <code>adapters/{go,django,rails,php}/</code>, with runnable demos under <code>examples/</code>.</p>
+    <p>An adapter is the small render-agnostic piece in your app that answers the protocol. Built-in adapters live under <code>adapters/{go,django,rails,php,flask,express}/</code>, with runnable demos under <code>examples/</code>.</p>
     <table>
       <thead><tr><th>stack</th><th>mount</th></tr></thead>
       <tbody>

--- a/docs/guide/adapters.md
+++ b/docs/guide/adapters.md
@@ -13,9 +13,11 @@ versions of a framework.
 | Django | `from swapbook_adapter import Registry` | `urlpatterns = reg.urls` |
 | Rails | `require "swapbook"` | `mount REG => "/_swapbook"` |
 | Laravel / PHP | `require "swapbook.php"` | route `/_swapbook/*` to `$sb->handle(...)` |
+| Flask | `from swapbook import Registry` | `app.register_blueprint(reg.blueprint)` |
+| Express | `require("swapbook")` | `app.use(reg.router())` |
 
-The adapter source lives under `adapters/{go,django,rails,php}/`. Runnable demos
-for every stack are under `examples/`.
+The adapter source lives under `adapters/{go,django,rails,php,flask,express}/`.
+Runnable demos for every stack are under `examples/`.
 
 ## Writing your own
 

--- a/examples/express/.gitignore
+++ b/examples/express/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/examples/express/package-lock.json
+++ b/examples/express/package-lock.json
@@ -1,0 +1,826 @@
+{
+  "name": "swapbook-express-example",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "swapbook-express-example",
+      "dependencies": {
+        "express": "^4.19.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "swapbook-express-example",
+  "private": true,
+  "description": "Swapbook demo target on Express, using the Express adapter.",
+  "dependencies": {
+    "express": "^4.19.0"
+  }
+}

--- a/examples/express/target.js
+++ b/examples/express/target.js
@@ -1,0 +1,30 @@
+// Swapbook demo target on Express, using the Express adapter. Renders a subset
+// of the shared demo design system (same ds.css classes as the other demos).
+// Run:  node examples/express/target.js [port]   (npm install first)
+"use strict";
+const fs = require("fs");
+const path = require("path");
+const express = require("express");
+const { Registry, mock, variant } = require("../../adapters/express/swapbook");
+
+const BTN = '<button class="btn btn-primary">Save</button>';
+const TODO =
+  '<div class="todo"><ul id="rows"><li>Write the launch post</li><li>Record the demo gif</li></ul>' +
+  '<button class="btn btn-secondary" hx-get="/ds/row" hx-target="#rows" hx-swap="beforeend">+ add row</button></div>';
+
+const reg = new Registry({ cssSrc: "/static/ds.css" });
+reg.register("Button", [variant("primary", () => BTN)], { group: "actions", docs: "The button primitive, from a raw Express server." });
+reg.register("Todo list", [
+  variant("default", () => TODO, { docs: "Click **+ add row**.", mocks: [mock("GET /ds/row", () => "<li>New task</li>")] }),
+], { group: "interactive" });
+
+const app = express();
+app.use(reg.router());
+app.get("/static/ds.css", (_req, res) => {
+  for (const cand of ["examples/shared/ds.css", path.join(__dirname, "..", "shared", "ds.css")]) {
+    if (fs.existsSync(cand)) return res.type("css").send(fs.readFileSync(cand, "utf8"));
+  }
+  res.sendStatus(404);
+});
+
+app.listen(Number(process.argv[2]) || 9096);

--- a/examples/flask/app.py
+++ b/examples/flask/app.py
@@ -1,0 +1,39 @@
+# Swapbook demo target on Flask, using the Flask adapter. Renders a subset of
+# the shared demo design system (same ds.css classes as the other demos).
+# Run:  PYTHONPATH=adapters/flask python3 examples/flask/app.py [port]
+import os
+import sys
+
+from flask import Flask
+from swapbook import Registry, mock, variant
+
+BTN = '<button class="btn btn-primary">Save</button>'
+TODO = (
+    '<div class="todo"><ul id="rows">'
+    "<li>Write the launch post</li><li>Record the demo gif</li>"
+    '</ul><button class="btn btn-secondary" hx-get="/ds/row" hx-target="#rows" hx-swap="beforeend">+ add row</button></div>'
+)
+
+reg = Registry(css_src="/static/ds.css")
+reg.register("Button", [variant("primary", lambda a: BTN)], group="actions",
+             docs="The button primitive, from a raw Flask server.")
+reg.register("Todo list", [
+    variant("default", lambda a: TODO, docs="Click **+ add row**.",
+            mocks=[mock("GET /ds/row", lambda a: "<li>New task</li>")]),
+], group="interactive")
+
+app = Flask(__name__)
+app.register_blueprint(reg.blueprint)
+
+
+@app.route("/static/ds.css")
+def ds_css():
+    for cand in ("examples/shared/ds.css", os.path.join(os.path.dirname(__file__), "..", "shared", "ds.css")):
+        if os.path.exists(cand):
+            with open(cand, encoding="utf-8") as f:
+                return f.read(), 200, {"Content-Type": "text/css; charset=utf-8"}
+    return "", 404
+
+
+if __name__ == "__main__":
+    app.run(port=int(sys.argv[1]) if len(sys.argv) > 1 else 9095)

--- a/examples/smoke.sh
+++ b/examples/smoke.sh
@@ -18,8 +18,8 @@ TARGETS=(
   "python|python3 examples/python/target.py|9090|7101|raw Python server"
   "node|node examples/node/target.js|9091|7102|raw Node server"
   "ruby|ruby examples/ruby/target.rb|9092|7103|raw Ruby server"
-  "flask|PYTHONPATH=adapters/flask python3 examples/flask/app.py|9093|7104|raw Flask server"
-  "express|NODE_PATH=examples/express/node_modules node examples/express/target.js|9094|7105|raw Express server"
+  "flask|env PYTHONPATH=adapters/flask python3 examples/flask/app.py|9093|7104|raw Flask server"
+  "express|env NODE_PATH=examples/express/node_modules node examples/express/target.js|9094|7105|raw Express server"
 )
 
 fail=0

--- a/examples/smoke.sh
+++ b/examples/smoke.sh
@@ -18,6 +18,8 @@ TARGETS=(
   "python|python3 examples/python/target.py|9090|7101|raw Python server"
   "node|node examples/node/target.js|9091|7102|raw Node server"
   "ruby|ruby examples/ruby/target.rb|9092|7103|raw Ruby server"
+  "flask|PYTHONPATH=adapters/flask python3 examples/flask/app.py|9093|7104|raw Flask server"
+  "express|NODE_PATH=examples/express/node_modules node examples/express/target.js|9094|7105|raw Express server"
 )
 
 fail=0


### PR DESCRIPTION
## What

Two more built-in adapters, so the protocol runs on **Flask** (Python) and **Express** (Node) alongside Go/Django/Rails/Laravel. Both implement the full protocol (manifest / preview / mocks / mock with status), controls, viewports and play, mirroring the existing adapters.

- **Flask**: `app.register_blueprint(reg.blueprint)`. Variant render is a callable `(args) -> str`.
- **Express**: `app.use(reg.router())`. Variant render is `(args) => htmlString`.

```python
# Flask
from swapbook import Registry, variant, mock
reg = Registry(css_src="/static/app.css")
reg.register("Button", [variant("primary", lambda a: render_button())])
app.register_blueprint(reg.blueprint)
```

```js
// Express
const { Registry, variant } = require("swapbook");
const reg = new Registry({ cssSrc: "/static/app.css" });
reg.register("Button", [variant("primary", () => renderButton())]);
app.use(reg.router());
```

## Tests
- A runnable demo per stack (`examples/flask`, `examples/express`) and both are wired into the protocol smoke suite (`examples/smoke.sh` + `pip install flask` / `npm install` in the CI job), so their manifest → preview → mock flow is regression-tested end to end behind the binary.
- Verified locally: `swapbook check` passes against both demos; the todo mock renders.

## Scope
Flask + Express are the cheap, high-audience wins (references already existed). Phoenix, Spring and others stay community adapters, seeded by the authoring guide.

Docs: adapters table (guide + site) and the README stack count updated.