### PR TITLE
ci: rename smoke job to match the updated required check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
           if-no-files-found: ignore
 
   smoke:
-    name: protocol smoke (python/node/ruby)
+    name: protocol smoke (python/node/ruby/flask/express)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The branch ruleset's required status check is now `protocol smoke (python/node/ruby/flask/express)`; rename the job so it reports under that name (it already runs the Flask + Express targets). This PR's own run emits the new-named check, so it stays mergeable.